### PR TITLE
Fix multiple occurences of `-` or `_` in tokens

### DIFF
--- a/js/jwt.js
+++ b/js/jwt.js
@@ -11,7 +11,7 @@ window.hextorstr = function (c) {
 
 //this is used to parse base64
 function url_base64_decode(str) {
-  var output = str.replace('-', '+').replace('_', '/');
+  var output = str.replace(/-/g, '+').replace(/_/g, '/');
   switch (output.length % 4) {
     case 0:
       break;

--- a/test/test.js
+++ b/test/test.js
@@ -16,4 +16,9 @@ describe('jwt library wrapper (jwt.js)', function () {
     expect(result.error).to.be.equal(null);
     expect(result.result).to.be(true);
   });
+  it('should decode with two underscores', function () {
+    var result = window.decode('eyI_IjoiYWE_In0');
+    expect(result.error).to.be.equal(null);
+    expect(result.result).to.be('{\n  "?": "aa?"\n}');
+  });
 });


### PR DESCRIPTION
String replacements replaced only the first occurence of `-` or `_` in tokens for base64 decoding, which meant that there was a base64 decode error if more than one of either was present in the base64url format. Use regexps in replacement instead to get a global match.

Fixes #26.