### PR TITLE
Remove “Maintainer:” for more space

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -169,7 +169,7 @@
                 </div>
               </div>
               <div class="author-info">
-                <div class="maintainer"><i class="icon-budicon-333"></i>Maintainer: Microsoft</div>
+                <div class="maintainer"><i class="icon-budicon-333"></i>Microsoft</div>
 
                 <div class="repository"><i class="fa fa-github"></i> <a href="https://github.com/MSOpenTech/azure-activedirectory-identitymodel-extensions-for-dotnet">View Repo</a></div>
               </div>
@@ -213,7 +213,7 @@
               </div>
               <div class="author-info">
                 <div class="maintainer">
-                  <i class="icon-budicon-333"></i>Maintainer: <a href="https://github.com/progrium">Jeff Lindsay</a>
+                  <i class="icon-budicon-333"></i><a href="https://github.com/progrium">Jeff Lindsay</a>
                 </div>
 
                 <div class="repository">
@@ -263,7 +263,7 @@
               <div class="author-info">
 
                 <div class="maintainer">
-                  <i class="icon-budicon-333"></i>Maintainer: <a href="https://github.com/auth0">Auth0</a>
+                  <i class="icon-budicon-333"></i><a href="https://github.com/auth0">Auth0</a>
                 </div>
 
                 <div class="repository">
@@ -314,7 +314,7 @@
               </div>
               <div class="author-info">
 
-                <div class='maintainer'><i class="icon-budicon-333"></i>Maintainer: <a href="https://github.com/auth0">Auth0</a></div>
+                <div class='maintainer'><i class="icon-budicon-333"></i><a href="https://github.com/auth0">Auth0</a></div>
 
                 <div class="repository">
                   <i class="fa fa-github"></i> <a href="https://github.com/auth0/java-jwt">View Repo</a>
@@ -364,7 +364,7 @@
 
               <div class="author-info">
 
-                <div class="maintainer"><i class="icon-budicon-333"></i>Maintainer: <a href="https://github.com/firebase">Firebase</a></div>
+                <div class="maintainer"><i class="icon-budicon-333"></i><a href="https://github.com/firebase">Firebase</a></div>
 
                 <div class="repository">
                   <i class="fa fa-github"></i> <a href="https://github.com/firebase/php-jwt">View Repo</a>
@@ -416,7 +416,7 @@
               </div>
 
               <div class="author-info">
-                <div class="maintainer"><i class="icon-budicon-333"></i>Maintainer: <a href="https://github.com/progrium">Jeff Lindsay</a></div>
+                <div class="maintainer"><i class="icon-budicon-333"></i><a href="https://github.com/progrium">Jeff Lindsay</a></div>
 
 
                 <div class="repository">
@@ -476,7 +476,7 @@
               <div class="author-info">
 
 
-                <div class="maintainer"><i class="icon-budicon-333"></i>Maintainer: <a href="https://github.com/dgrijalva">dgrijalva</a></div>
+                <div class="maintainer"><i class="icon-budicon-333"></i><a href="https://github.com/dgrijalva">dgrijalva</a></div>
 
                 <div class="repository">
                   <i class="fa fa-github"></i> <a href="https://github.com/dgrijalva/jwt-go">View Repo</a>
@@ -532,7 +532,7 @@
 
               <div class="author-info">
 
-                <div class="maintainer"><i class="icon-budicon-333"></i>Maintainer: <a href="https://github.com/kjur">Kenji Urushima</a></div>
+                <div class="maintainer"><i class="icon-budicon-333"></i><a href="https://github.com/kjur">Kenji Urushima</a></div>
 
                 <div class="repository">
                   <i class="fa fa-github"></i> <a href="https://github.com/kjur/jsjws">View Repo</a>
@@ -587,7 +587,7 @@
 
               <div class="author-info">
 
-                <div class="maintainer"><i class="icon-budicon-333"></i>Maintainer: <a href="https://bitbucket.org/ssaasen">Stefan Saasen</a></div>
+                <div class="maintainer"><i class="icon-budicon-333"></i><a href="https://bitbucket.org/ssaasen">Stefan Saasen</a></div>
 
                 <div class="repository">
                   <i class="fa fa-bitbucket"></i> <a href="https://bitbucket.org/ssaasen/haskell-jwt">View Repo</a>

--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
     <link rel="search" type="application/opensearchdescription+xml" title="JWT.io" href="/opensearch.xml">
 
     <!-- Bootstrap core CSS -->
+
     <link href="//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css" rel="stylesheet">
 
     <!-- Just for debugging purposes. Don't actually copy this line! -->
@@ -163,7 +164,7 @@
                 </div>
               </div>
               <div class="author-info">
-                <div class="maintainer"><i class="icon-budicon-333"></i>Maintainer: Microsoft</div>
+                <div class="maintainer"><i class="icon-budicon-333"></i>Microsoft</div>
 
                 <div class="repository"><i class="fa fa-github"></i> <a href="https://github.com/MSOpenTech/azure-activedirectory-identitymodel-extensions-for-dotnet">View Repo</a></div>
               </div>
@@ -207,7 +208,7 @@
               </div>
               <div class="author-info">
                 <div class="maintainer">
-                  <i class="icon-budicon-333"></i>Maintainer: <a href="https://github.com/progrium">Jeff Lindsay</a>
+                  <i class="icon-budicon-333"></i><a href="https://github.com/progrium">Jeff Lindsay</a>
                 </div>
 
                 <div class="repository">
@@ -257,7 +258,7 @@
               <div class="author-info">
 
                 <div class="maintainer">
-                  <i class="icon-budicon-333"></i>Maintainer: <a href="https://github.com/auth0">Auth0</a>
+                  <i class="icon-budicon-333"></i><a href="https://github.com/auth0">Auth0</a>
                 </div>
 
                 <div class="repository">
@@ -308,7 +309,7 @@
               </div>
               <div class="author-info">
 
-                <div class="maintainer"><i class="icon-budicon-333"></i>Maintainer: <a href="https://github.com/auth0">Auth0</a></div>
+                <div class="maintainer"><i class="icon-budicon-333"></i><a href="https://github.com/auth0">Auth0</a></div>
 
                 <div class="repository">
                   <i class="fa fa-github"></i> <a href="https://github.com/auth0/java-jwt">View Repo</a>
@@ -358,7 +359,7 @@
 
               <div class="author-info">
 
-                <div class="maintainer"><i class="icon-budicon-333"></i>Maintainer: <a href="https://github.com/firebase">Firebase</a></div>
+                <div class="maintainer"><i class="icon-budicon-333"></i><a href="https://github.com/firebase">Firebase</a></div>
 
                 <div class="repository">
                   <i class="fa fa-github"></i> <a href="https://github.com/firebase/php-jwt">View Repo</a>
@@ -410,7 +411,7 @@
               </div>
 
               <div class="author-info">
-                <div class="maintainer"><i class="icon-budicon-333"></i>Maintainer: <a href="https://github.com/progrium">Jeff Lindsay</a></div>
+                <div class="maintainer"><i class="icon-budicon-333"></i><a href="https://github.com/progrium">Jeff Lindsay</a></div>
 
 
                 <div class="repository">
@@ -470,7 +471,7 @@
               <div class="author-info">
 
 
-                <div class="maintainer"><i class="icon-budicon-333"></i>Maintainer: <a href="https://github.com/dgrijalva">dgrijalva</a></div>
+                <div class="maintainer"><i class="icon-budicon-333"></i><a href="https://github.com/dgrijalva">dgrijalva</a></div>
 
                 <div class="repository">
                   <i class="fa fa-github"></i> <a href="https://github.com/dgrijalva/jwt-go">View Repo</a>
@@ -526,7 +527,7 @@
 
               <div class="author-info">
 
-                <div class="maintainer"><i class="icon-budicon-333"></i>Maintainer: <a href="https://github.com/kjur">Kenji Urushima</a></div>
+                <div class="maintainer"><i class="icon-budicon-333"></i><a href="https://github.com/kjur">Kenji Urushima</a></div>
 
                 <div class="repository">
                   <i class="fa fa-github"></i> <a href="https://github.com/kjur/jsjws">View Repo</a>
@@ -581,7 +582,7 @@
 
               <div class="author-info">
 
-                <div class="maintainer"><i class="icon-budicon-333"></i>Maintainer: <a href="https://bitbucket.org/ssaasen">Stefan Saasen</a></div>
+                <div class="maintainer"><i class="icon-budicon-333"></i><a href="https://bitbucket.org/ssaasen">Stefan Saasen</a></div>
 
                 <div class="repository">
                   <i class="fa fa-bitbucket"></i> <a href="https://bitbucket.org/ssaasen/haskell-jwt">View Repo</a>


### PR DESCRIPTION
Having “Maintainer:” in each of the libraries didn’t play such an important part plus it made some of them look bad where the maintainer name was too long and the View Repo would just get misaligned.

Before
![jwtio-before](https://cloud.githubusercontent.com/assets/83319/5514985/3b98a52e-882b-11e4-89fd-7153f6fd95dc.png)

After
![jwtio-after](https://cloud.githubusercontent.com/assets/83319/5514987/5345f618-882b-11e4-8b0d-1708170f17fc.png)
