### PR TITLE
Added additional URL parameters for secret/base64

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -194,10 +194,21 @@
     var d = {};
     qs = qs.split('&');
     qs.forEach(function (kv) { kv = kv.split('='); d[kv[0]] = kv[1]; });
+    var changed = false;
     if (d.value) {
       tokenEditor.setValue(decodeURIComponent(d.value));
-      return;
+      changed = true;
     }
+    if (d.secret) {
+      $(secretElement).val(decodeURIComponent(d.secret));
+      changed = true;
+    }
+    if (d.base64) {
+      $(isBase64EncodedElement).prop('checked',d.base64 == 'true');
+      changed = true;
+    }
+
+    if ( changed ) return;
   }
 
   loadFromStorage(function (jwt) {


### PR DESCRIPTION
I want to be able to verify a JWT by clicking a link.  For convenience, I'd like to be able to send ALL of the parameters via the URL, rather than having to find and copy and paste in the secret.

Doing so does potentially pose a minor security threat.  Someone monitoring my communications with jwt.io might be able to sniff out my signing secret.  So using this feature with a production secret might be a bad idea.  But if loss of the secret key does not pose a threat, a developer could use this feature to increase the convenience of validating a JWT in a single click.  This is intended primarily for someone who is testing out their JWT creation or validation code and wants to keep it simple.

I suggest that people well versed in the seriousness of the threat consider the ramifications of making this feature available before accepting the pull request.  That said, if it is not used, it is not a threat.  Those that choose to use it would be exposing their signing secret.  But in some environments, it's not really being "exposed" to anyone who doesn't already have it. 

Clearly, even I'm torn as to whether or not this is an acceptable feature to implement.  But I lean towards enabling convenience and let the user decide if the risk is too great to use it.