### PR TITLE
fix the composer installation instruction

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -762,7 +762,7 @@
 
             <div class="panel-footer">
               <div>
-                <code>composer namshi/jose</code>
+                <code>composer require namshi/jose</code>
               </div>
 
             </div>


### PR DESCRIPTION
the instructions are right for one of the PHP library, but invalid for the second one. The command was missing