### PR TITLE
Added JSONWebToken (Swift)

### DIFF
--- a/index.html
+++ b/index.html
@@ -919,6 +919,57 @@
           </div>
         </div>
 
+        <!-- Swift kylef/JSONWebToken.swift -->
+        <div class="col-md-4">
+          <div class="panel panel-default">
+            <div class="panel-heading">
+              <h3 class="panel-title">Swift</h3>
+            </div>
+            <div class="panel-body library">
+              <div class="row">
+
+                <div class="col-md-6">
+                  <div><i class="icon-budicon-500"></i>Sign</div>
+                  <div><i class="icon-budicon-500"></i>Verify</div>
+                  <div><i class="icon-budicon-500"></i><code>iss</code> check</div>
+                  <div><i class="icon-budicon-501"></i><code>sub</code> check</div>
+                  <div><i class="icon-budicon-500"></i><code>aud</code> check</div>
+                  <div><i class="icon-budicon-500"></i><code>exp</code> check</div>
+                  <div><i class="icon-budicon-500"></i><code>nbf</code> check</div>
+                  <div><i class="icon-budicon-500"></i><code>iat</code> check</div>
+                  <div><i class="icon-budicon-501"></i><code>jti</code> check</div>
+                </div>
+                <div class="col-md-6">
+
+                  <div><i class="icon-budicon-500"></i>HS256</div>
+                  <div><i class="icon-budicon-500"></i>HS384</div>
+                  <div><i class="icon-budicon-500"></i>HS512</div>
+                  <div><i class="icon-budicon-501"></i>RS256</div>
+                  <div><i class="icon-budicon-501"></i>RS384</div>
+                  <div><i class="icon-budicon-501"></i>RS512</div>
+                  <div><i class="icon-budicon-501"></i>ES256</div>
+                  <div><i class="icon-budicon-501"></i>ES384</div>
+                  <div><i class="icon-budicon-501"></i>ES512</div>
+                </div>
+
+              </div>
+              <div class="author-info">
+
+                <div class="maintainer"><i class="icon-budicon-333"></i>Maintainer: <a href="https://github.com/kylef">Kyle Fuller</a></div>
+
+                <div class="repository">
+                  <i class="fa fa-github"></i> <a href="https://github.com/kylef/JSONWebToken.swift">View Repo</a>
+                </div>
+
+              </div>
+            </div>
+
+            <div class="panel-footer">
+              <code>pod 'JSONWebToken'</code>
+            </div>
+          </div>
+        </div>
+
       </div>
     </div>
 


### PR DESCRIPTION
This pull request adds a Swift implementation of JWT that I recently built: https://github.com/kylef/JSONWebToken.swift

I took the advice from the recent [security post](https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/). You must provide all algorithms and the associated keys when decoding a JWT. Verification will succeed when any of the algorithm or keys match.

```swift
JWT.decode("eyJh...5w", [.HS256("secret"), .HS256("secret2"), .HS512("secure")])
```