### PR TITLE
Fix wrong package install command for Lua library

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -818,7 +818,8 @@
             </div>
 
             <div class="panel-footer">
-              <code>curl https://codeload.github.com/SkyLothar/lua-resty-jwt/tar.gz/master | tar -xz</code>
+              <code>curl https://codeload.github.com/SkyLothar/lua-resty-jwt/tar.gz/master | tar -xz --strip 1 lua-resty-jwt-master/lib</code>
+              <code>curl https://codeload.github.com/jkeys089/lua-resty-hmac/tar.gz/master | tar -xz --strip 1 lua-resty-hmac-master/lib</code>
             </div>
           </div>
         </div>

--- a/html/index.html
+++ b/html/index.html
@@ -818,7 +818,7 @@
             </div>
 
             <div class="panel-footer">
-              <code>sbt: "com.jason-goodwin" %% "authentikat-jwt" % "0.3.5" </code>
+              <code>curl https://codeload.github.com/SkyLothar/lua-resty-jwt/tar.gz/master | tar -xz</code>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Looks like the command for Scala was accidentally used instead.
The lua-resty-jwt lib doesn't use LuaRocks, so my suggested command just downloads and unzips the current source.