### PR TITLE
Add Haskell 'jose' library

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -1063,6 +1063,63 @@
         </div>
 
       </div>
+
+      <div class="row">
+        <!-- Haskell frasertweedale/hs-jose -->
+        <div class="col-md-4">
+          <div class="panel panel-default">
+            <div class="panel-heading">
+              <h3 class="panel-title">Haskell</h3>
+            </div>
+            <div class="panel-body library">
+              <div class="row">
+                <div class="col-md-6">
+                  <div><i class="icon-budicon-500"></i>Sign</div>
+                  <div><i class="icon-budicon-500"></i>Verify</div>
+                  <div><i class="icon-budicon-501"></i><code>iss</code> check</div>
+                  <div><i class="icon-budicon-501"></i><code>sub</code> check</div>
+                  <div><i class="icon-budicon-501"></i><code>aud</code> check</div>
+                  <div><i class="icon-budicon-501"></i><code>exp</code> check</div>
+                  <div><i class="icon-budicon-501"></i><code>nbf</code> check</div>
+                  <div><i class="icon-budicon-501"></i><code>iat</code> check</div>
+                  <div><i class="icon-budicon-501"></i><code>jti</code> check</div>
+                </div>
+                <div class="col-md-6">
+                  <div><i class="icon-budicon-500"></i>HS256</div>
+                  <div><i class="icon-budicon-500"></i>HS384</div>
+                  <div><i class="icon-budicon-500"></i>HS512</div>
+                  <div><i class="icon-budicon-500"></i>RS256</div>
+                  <div><i class="icon-budicon-500"></i>RS384</div>
+                  <div><i class="icon-budicon-500"></i>RS512</div>
+                  <div><i class="icon-budicon-500"></i>ES256</div>
+                  <div><i class="icon-budicon-500"></i>ES384</div>
+                  <div><i class="icon-budicon-500"></i>ES512</div>
+                </div>
+              </div>
+
+              <div class="author-info">
+
+                <a href="https://github.com/frasertweedale">
+                    <i
+                        class="icon-budicon-333"
+                        data-toggle="tooltip"
+                        title="Maintainer: Fraser Tweedale"></i>
+                </a>
+
+                <div class="repository">
+                  <i class="fa fa-github"></i> <a href="https://github.com/frasertweedale/hs-jose">View Repo</a>
+                </div>
+              </div>
+
+            <div class="panel-footer">
+              <div>
+                <code>cabal install jose</code>
+              </div>
+            </div>
+          </div>
+        </div>
+        </div>
+      </div>
     </div>
 
 </div>


### PR DESCRIPTION
Add the Haskell 'jose' library which supports many more algorithms
than the 'jwt' library.

Disclosure: the author of this commit is the author of the 'jose'
library.