### PR TITLE
Adjust formatting of code reference for jose2go

### DIFF
--- a/html/libraries/go2.jade
+++ b/html/libraries/go2.jade
@@ -81,6 +81,4 @@ article.jwt-go.go.accordion(data-accordion)
         a(href='https://github.com/dvsekhvalnov/jose2go') View Repo
 
     .panel-footer
-      code
-        | go get
-        a(href='https://github.com/dvsekhvalnov/jose2go') github.com/dvsekhvalnov/jose2go
+      code go get github.com/dvsekhvalnov/jose2go


### PR DESCRIPTION
This adjusts the reference to the github url for jose2go so that it reads "go get github.com/dvsekhvalnov/jose2go" rather than "go getgithub.com/dvsekhvalnov/jose2go" when viewed in the http://jwt.io/ site.