### PR TITLE
Remove js-classifier for code block

### DIFF
--- a/views/md/introduction.md
+++ b/views/md/introduction.md
@@ -56,7 +56,7 @@ From the user's perspective, logging in to an application that uses JWTs looks m
 
 The JWT must be sent to the server to access protected routes, and it is typically sent as an `Authorization` header. The scheme used for this header is `Bearer`, so the full header looks like this:
 
-```js
+```
 Authorization: Bearer <token>
 ```
 


### PR DESCRIPTION
using a `js` classifier looks fine on github, but on the [Introduction page](http://jwt.io/introduction/) it doesn't know what to do with it and appends it to the code sample - which make it look a bit confusing:

```
js Authorization: Bearer <token>
```

instead of 

```
Authorization: Bearer <token>
```

btw i'm not sure why the last line is shown as edited as well, maybe problems w/ line-endings (used the github interface for editing the file .. oO)? the only thing i intended to do was remove the `js` classifier in L59