### PR TITLE
updated status for firebase/php-jwt

### DIFF
--- a/views/libraries/php.jade
+++ b/views/libraries/php.jade
@@ -11,17 +11,17 @@ article.jwt-php.php.accordion(data-accordion)
     .panel-body.mversion
       .column
         p
-          i.icon-budicon-501
+          i.icon-budicon-500
           | Sign
         p
           i.icon-budicon-500
           | Verify
         p
-          i.icon-budicon-501
+          i.icon-budicon-500
           code iss
           |  check
         p
-          i.icon-budicon-501
+          i.icon-budicon-500
           code sub
           |  check
         p
@@ -41,7 +41,7 @@ article.jwt-php.php.accordion(data-accordion)
           code iat
           |  check
         p
-          i.icon-budicon-501
+          i.icon-budicon-500
           code jti
           |  check
       .column
@@ -55,7 +55,7 @@ article.jwt-php.php.accordion(data-accordion)
           i.icon-budicon-501
           | HS512
         p
-          i.icon-budicon-501
+          i.icon-budicon-500
           | RS256
         p
           i.icon-budicon-500


### PR DESCRIPTION
Using the debugger, I just verified that firebase/php-jwt does support signing, iss, sub and jti in the payload. It can also sign with RS256.