### PR TITLE
No ECDSA in System.IdentityModel.Tokens.Jwt

### DIFF
--- a/views/libraries/net.jade
+++ b/views/libraries/net.jade
@@ -60,13 +60,13 @@ article.jwt-net.net.accordion(data-accordion)
           i.icon-budicon-500
           | RS512
         p
-          i.icon-budicon-500
+          i.icon-budicon-501
           | ES256
         p
-          i.icon-budicon-500
+          i.icon-budicon-501
           | ES384
         p
-          i.icon-budicon-500
+          i.icon-budicon-501
           | ES512
 
     .author-info


### PR DESCRIPTION
ECDSA support has landed on a dev branch in this library's repo, but not yet in any release or prerelease build.