### PR TITLE
Adding support for public_key parameter in hash

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -631,6 +631,14 @@ FaFp+DyAe+b4nDwuJaW2LURbr8AEZga7oQj0uYxcYw==\n\
     qs.forEach(function (kv) { kv = kv.split('='); d[kv[0]] = kv[1]; });
     if (d.id_token) {
       tokenEditor.setValue(decodeURIComponent(d.id_token));
+      
+      if (d.public_key) {
+        var key = '-----BEGIN PUBLIC KEY-----\n' +
+                  decodeURIComponent(d.public_key) +
+                  '\n-----END PUBLIC KEY-----';
+        $('.jwt-signature textarea[name=public-key]').val(key);
+        updateSignature();
+      }
       return;
     }
   }


### PR DESCRIPTION
Adding ability to supply a `public_key` in hash of URL so that you can link to jwt.io and demonstrate signature verification using RS256.

e.g.

https://jwt.io/#id_token={token}&public_key={public_key}

For the `public_key` I've removed the need for the `-----BEGIN PUBLIC KEY-----\n` prefix and the `\n-----END PUBLIC KEY-----` suffix.

Thanks to @reuvensh for help on this.
