### PR TITLE
Change jsrsasign install from bower to npm

### DIFF
--- a/views/libraries/js.jade
+++ b/views/libraries/js.jade
@@ -85,4 +85,4 @@ article.jwt-js.js.accordion(data-accordion)
         a(href='https://github.com/kjur/jsrsasign') View Repo
 
     .panel-footer
-      code bower install jsrsasign
+      code npm install jsrsasign


### PR DESCRIPTION
Change jsrsasign installation command from bower to npm.

Currently, Bower is legacy and not standard package registry and NPM is more standard.
(I got misconception "jsrsasign is may not be maintained because installation only Bower".)

see: http://blog.npmjs.org/post/101775448305/npm-and-front-end-packaging
