### PR TITLE
Grammar error

### DIFF
--- a/views/md/introduction.md
+++ b/views/md/introduction.md
@@ -5,7 +5,7 @@ JSON Web Token (JWT) is an open standard ([RFC 7519](https://tools.ietf.org/html
 
 Let's explain some concepts of this definition further.
 
-- **Compact**: Because of its smaller size, JWTs can be sent through an URL, POST parameter, or inside an HTTP header. Additionally, the smaller size means transmission is fast.
+- **Compact**: Because of its smaller size, JWTs can be sent through a URL, POST parameter, or inside an HTTP header. Additionally, the smaller size means transmission is fast.
 
 - **Self-contained**: The payload contains all the required information about the user, avoiding the need to query the database more than once.
 

--- a/views/md/introduction.md
+++ b/views/md/introduction.md
@@ -5,7 +5,7 @@ JSON Web Token (JWT) is an open standard ([RFC 7519](https://tools.ietf.org/html
 
 Let's explain some concepts of this definition further.
 
-- **Compact**: Because of its smaller size, JWTs can be sent through a URL, POST parameter, or inside an HTTP header. Additionally, the smaller size means transmission is fast.
+- **Compact**: Because of their smaller size, JWTs can be sent through a URL, POST parameter, or inside an HTTP header. Additionally, the smaller size means transmission is fast.
 
 - **Self-contained**: The payload contains all the required information about the user, avoiding the need to query the database more than once.
 


### PR DESCRIPTION
```
   In the first paragraph, "What is JSON Web Token?", change "an" to "a" before the word "URL." According to Ivy Wigmore, "Although the 'U' at the beginning of 'URL' is a vowel, the abbreviation is pronounced 'you-are-ell.' Because the letter 'Y' is a consonant in this case, use 'a' rather than 'an.'" @URL: http://itknowledgeexchange.techtarget.com/writing-for-business/which-is-correct-a-url-or-an-url/ 
```

Please apply this very basic grammatical logic when writing articles in the future.
