### PR TITLE
Fix local test execution

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,6 @@
     "bower": "^1.4.1",
     "express": "^4.13.4",
     "express-sslify": "^1.0.1",
-    "marked": "^0.3.5",
-    "serve": "*",
     "grunt": "^0.4.5",
     "grunt-cli": "^1.2.0",
     "grunt-contrib-clean": "^0.6.0",
@@ -19,12 +17,17 @@
     "grunt-contrib-stylus": "^0.21.0",
     "grunt-contrib-uglify": "^0.5.1",
     "grunt-contrib-watch": "^0.6.1",
-    "grunt-mocha-phantomjs": "0.7.0",
+    "grunt-mocha-phantomjs": "^4.0.0",
     "grunt-usemin": "^2.0.2",
-    "matchdep": "~0.3.0"
+    "marked": "^0.3.5",
+    "matchdep": "~0.3.0",
+    "serve": "*"
   },
   "devDependencies": {
-    "expect.js": "^0.3.1"
+    "expect.js": "^0.3.1",
+    "mocha": "^3.2.0",
+    "mocha-phantomjs": "^4.1.0",
+    "phantomjs-prebuilt": "^2.1.14"
   },
   "scripts": {
     "test": "grunt test --verbose",

--- a/test/test_harness.html
+++ b/test/test_harness.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="utf-8">
   <title>Mocha Tests</title>
-  <link rel="stylesheet" href="../node_modules/grunt-mocha-phantomjs/node_modules/mocha-phantomjs/node_modules/mocha/mocha.css" />
+  <link rel="stylesheet" href="../node_modules/mocha/mocha.css" />
 </head>
 <body>
   <div id="mocha"></div>
 
-  <script src="../node_modules/grunt-mocha-phantomjs/node_modules/mocha-phantomjs/node_modules/mocha/mocha.js"></script>
+  <script src="../node_modules/mocha/mocha.js"></script>
   <script src="../node_modules/expect.js/index.js"></script>
 
   <script>


### PR DESCRIPTION
* Add phantomjs-prebuilt dependency to not require global phantomjs
* Add mocha dev dependency and point test harness to it
* Update version of grunt-mocha-phantomjs to fix Sierra segfault

Tests now work "out of the box" without needing global dependencies.