### PR TITLE
Change jwt-core Scala to version 0.9.2

### DIFF
--- a/views/libraries/scala2.jade
+++ b/views/libraries/scala2.jade
@@ -81,4 +81,4 @@ article.jwt-scala.scala.accordion(data-accordion)
         a(href='https://github.com/pauldijou/jwt-scala') View Repo
 
     .panel-footer
-      code sbt: "pdi" %% "jwt-core" % "0.4.1"
+      code sbt: "pdi" %% "jwt-core" % "0.9.2"


### PR DESCRIPTION
Just saw that here is an outdated version listed. Regarding `sub`, `iat` and `jti`, I saw that this is included in the code. I haven't verified it so far, but since there are no issues on their repo I assume this works as well now.