### PR TITLE
Update vapor/jwt major version in the footer

### DIFF
--- a/views/libraries/swift2.jade
+++ b/views/libraries/swift2.jade
@@ -81,4 +81,4 @@ article.jwt-scala.swift.accordion(data-accordion)
         a(href='https://github.com/vapor/jwt') View Repo
 
     .panel-footer
-      code .Package(url:"https://github.com/vapor/jwt.git", majorVersion: 0)
+      code .Package(url:"https://github.com/vapor/jwt.git", majorVersion: 1)


### PR DESCRIPTION
The current stable version of the vapor/jwt library is 1.0.1, which includes a critical fix.
Therefore it would be best if the page suggested installing this branch, not the outdated development versions.