### PR TITLE
Update io.igl.jwt lib to reflect package updates

### DIFF
--- a/views/libraries/scala3.jade
+++ b/views/libraries/scala3.jade
@@ -51,7 +51,7 @@ article.jwt-scala.scala.accordion(data-accordion)
           i.icon-budicon-500
           | HS512
         p
-          i.icon-budicon-501
+          i.icon-budicon-500
           | RS256
         p
           i.icon-budicon-501
@@ -81,4 +81,4 @@ article.jwt-scala.scala.accordion(data-accordion)
         a(href='https://github.com/iain-logan/jwt') View Repo
 
     .panel-footer
-      code libraryDependencies += "io.igl" %% "jwt" % "1.2.0"
+      code libraryDependencies += "io.igl" %% "jwt" % "1.2.2"


### PR DESCRIPTION
RS256 is now implemented in this package.
Updated dependency instructions to target latest version.