### PR TITLE
Replace rust with rust2 entry in index.jade

### DIFF
--- a/views/index.jade
+++ b/views/index.jade
@@ -218,7 +218,7 @@ block content
         include libraries/go5.jade
         include libraries/haskell.jade
         include libraries/haskell2.jade
-        include libraries/rust.jade
+        include libraries/rust2.jade
         include libraries/lua.jade
         include libraries/scala.jade
         include libraries/scala2.jade


### PR DESCRIPTION
The library in rust.jade, https://github.com/GildedHonour/frank_jwt, is of horribly low quality:

* commit descriptions are lacking
* error handling is not present and panics on every error, i.e. not suitable for anything more than very basic prototyping
* library is very inflexible, e.g. relies on files to read keys from (instead of allowing arbitrary sources).

In contrast, the library in rust2.jade is of much higher quality (even on first sight), but hasn't been included yet. I urge you to accept this request, as including bad libraries like frank_jwt harms your (and everyone's) cause here.