### PR TITLE
Add links to claims references, minor grammar fix

### DIFF
--- a/views/md/introduction.md
+++ b/views/md/introduction.md
@@ -49,15 +49,15 @@ Then, this JSON is **Base64Url** encoded to form the first part of the JWT.
 The second part of the token is the payload, which contains the claims. Claims are statements about an entity (typically, the user) and additional metadata.
 There are three types of claims: *reserved*, *public*, and *private* claims.
 
-- **Reserved claims**: These are a set of predefined claims which are not mandatory but recommended, to provide a set of useful, interoperable claims. Some of them are: **iss** (issuer), **exp** (expiration time), **sub** (subject), **aud** (audience), and others.
+- [**Reserved claims**](https://tools.ietf.org/html/rfc7519#section-4.1): These are a set of predefined claims which are not mandatory but recommended, to provide a set of useful, interoperable claims. Some of them are: **iss** (issuer), **exp** (expiration time), **sub** (subject), **aud** (audience), and [others](https://tools.ietf.org/html/rfc7519#section-4.1).
 
 	> Notice that the claim names are only three characters long as JWT is meant to be compact.
 
-- **Public claims**: These can be defined at will by those using JWTs. But to avoid collisions they should be defined in the IANA JSON Web Token Registry or be defined as a URI that contains a collision resistant namespace.
+- [**Public claims**](https://tools.ietf.org/html/rfc7519#section-4.2): These can be defined at will by those using JWTs. But to avoid collisions they should be defined in the [IANA JSON Web Token Registry](https://www.iana.org/assignments/jwt/jwt.xhtml) or be defined as a URI that contains a collision resistant namespace.
 
-- **Private claims**: These are the custom claims created to share information between parties that agree on using them.
+- [**Private claims**](https://tools.ietf.org/html/rfc7519#section-4.3): These are the custom claims created to share information between parties that agree on using them and are neither *reserved* or *public* claims.
 
-An example of payload could be:
+An example payload could be:
 
 ```
 {


### PR DESCRIPTION
This provides an easy-to-access link to get to the spec on what "others" relates to and what public claims exist in the IANA registry.