### PR TITLE
Updated ES256, ES384, ES512 support for System.IdentityModel.Tokens.Jwt

### DIFF
--- a/views/libraries/net.jade
+++ b/views/libraries/net.jade
@@ -60,13 +60,13 @@ article.jwt-net.net.accordion(data-accordion)
           i.icon-budicon-500
           | RS512
         p
-          i.icon-budicon-501
+          i.icon-budicon-500
           | ES256
         p
-          i.icon-budicon-501
+          i.icon-budicon-500
           | ES384
         p
-          i.icon-budicon-501
+          i.icon-budicon-500
           | ES512
 
     .author-info


### PR DESCRIPTION
Restored changes from PR #128, since ECDSA support is now available on stable version of System.IdentityModel.Tokens.Jwt.