### PR TITLE
Update crystal jwt repository

### DIFF
--- a/views/libraries/crystal.jade
+++ b/views/libraries/crystal.jade
@@ -74,11 +74,11 @@ article.jwt-crystal.crystal.accordion(data-accordion)
         a(href='https://github.com/greyblake')
           i.icon-budicon-333(data-toggle='tooltip', title='', data-original-title='Maintainer')
           | Sergey Potapov
-        span.stars(data-repo='greyblake/crystal-jwt', style='display: inline;')
+        span.stars(data-repo='crystal-community/jwt', style='display: inline;')
           i.icon-budicon-466
       .repository
         i.icon-1392070209-icon-social-github
-        a(href='https://github.com/greyblake/crystal-jwt') View Repo
+        a(href='https://github.com/crystal-community/jwt') View Repo
 
     .panel-footer
-      code git clone https://github.com/greyblake/crystal-jwt.git
+      code git clone https://github.com/crystal-community/jwt.git


### PR DESCRIPTION
Hi!

JWT solution for Crystal language has been moved to another repository. Author is the same.

From: [https://github.com/greyblake/crystal-jwt](https://github.com/greyblake/crystal-jwt)

To: [https://github.com/crystal-community/jwt](https://github.com/crystal-community/jwt)
