### PR TITLE
Add "gbrlsnchs/jwt" to Go libraries list

### DIFF
--- a/views/website/libraries.pug
+++ b/views/website/libraries.pug
@@ -79,6 +79,7 @@ section#libraries-io.libraries-jwt
       include libraries/go6.pug
       include libraries/go7.pug
       include libraries/go8.pug
+      include libraries/go9.pug
       include libraries/groovy.pug
       include libraries/haskell.pug
       include libraries/haskell2.pug

--- a/views/website/libraries/go9.pug
+++ b/views/website/libraries/go9.pug
@@ -1,0 +1,84 @@
+// Go gbrlsnchs/jwt
+article.jwt-go.go.accordion(data-accordion)
+  .panel-heading(data-control)
+    img(src='/img/8.svg')
+    h3 Go
+  .panel-wrap(data-content)
+    .panel-body
+      .column
+        p
+          i.icon-budicon-500
+          | Sign
+        p
+          i.icon-budicon-500
+          | Verify
+        p
+          i.icon-budicon-500
+          code iss
+          |  check
+        p
+          i.icon-budicon-500
+          code sub
+          |  check
+        p
+          i.icon-budicon-500
+          code aud
+          |  check
+        p
+          i.icon-budicon-500
+          code exp
+          |  check
+        p
+          i.icon-budicon-500
+          code nbf
+          |  check
+        p
+          i.icon-budicon-500
+          code iat
+          |  check
+        p
+          i.icon-budicon-500
+          code jti
+          |  check
+      .column
+        p
+          i.icon-budicon-500
+          | HS256
+        p
+          i.icon-budicon-500
+          | HS384
+        p
+          i.icon-budicon-500
+          | HS512
+        p
+          i.icon-budicon-500
+          | RS256
+        p
+          i.icon-budicon-500
+          | RS384
+        p
+          i.icon-budicon-500
+          | RS512
+        p
+          i.icon-budicon-500
+          | ES256
+        p
+          i.icon-budicon-500
+          | ES384
+        p
+          i.icon-budicon-500
+          | ES512
+
+    .author-info
+      .maintainer
+        a(href='https://github.com/gbrlsnchs')
+          i.icon-budicon-333(data-toggle='tooltip', title='', data-original-title='Maintainer')
+          | gbrlsnchs
+        span.stars(data-repo='gbrlsnchs/jwt', style='display: inline;')
+          i.icon-budicon-466
+      .repository
+        i.icon-1392070209-icon-social-github
+        a(href='https://github.com/gbrlsnchs/jwt') View Repo
+
+    .panel-footer
+      code go get github.com/gbrlsnchs/jwt


### PR DESCRIPTION
I have created a JWT library with support for all proposed signing methods and validation for all claims, enabling devs to also create custom validators.

I couldn't find the prerequisites to add a library to `jwt.io`, but I think what I've done so far is enough.

Thanks!