### PR TITLE
fix fragment callback parsing, parse other possible token from location

### DIFF
--- a/src/website/index.js
+++ b/src/website/index.js
@@ -5,7 +5,7 @@ import { setupTokenEditor, setTokenEditorValue } from '../editor';
 import { setupJwtCounter } from './counter.js';
 import { setupSmoothScrolling } from './smooth-scrolling.js';
 import { setupHighlighting } from './highlighting.js';
-import { getParameterByName } from '../utils.js';
+import { getParameterByName, getTokensFromLocation } from '../utils.js';
 import { isChrome, isFirefox } from './utils.js';
 import { 
   publicKeyTextArea, 
@@ -19,20 +19,17 @@ import {
 
 function parseLocationQuery() {
   const publicKey = getParameterByName('publicKey');
-  const value = getParameterByName('value');
-  const token = getParameterByName('token');
+  const { token, id_token, access_token, value } = getTokensFromLocation();
 
   let scroll = false;
   if(publicKey) {
     publicKeyTextArea.value = publicKey;
     scroll = true;
   }
-  if(value) {
-    setTokenEditorValue(value);
-    scroll = true;
-  }
-  if(token) {
-    setTokenEditorValue(token);
+
+  const val = value || token || id_token || access_token;
+  if(val) {
+    setTokenEditorValue(val);
     scroll = true;
   }
 


### PR DESCRIPTION
A common pattern for OAuth2 and OIDC callback testing is registering jwt.io as a redirect_uri to show the claims from an id_token or jwt formatted access_token immediately.

- fix parsing locations where the token might be the first parameter with no `?` at the beginning (response_mode=fragment) (1)
- parse id_token and access_token in addition to value and token (2)

```
(1)
https://jwt.io/#token=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InIxTGtiQm8zOTI1UmIyWkZGckt5VTNNVmV4OVQyODE3S3gwdmJpNmlfS2MifQ.eyJzdWIiOiJjOTUyNjUyNi05M2QxLTQzN2YtYTE0ZS1jMmFmODU2ODhkNTYiLCJub25jZSI6ImZvbyIsInNpZCI6IjU5MDQzNjlmLTNlNDQtNDc3Mi05ODY5LTM4ZWMwNmVmYThmNiIsImF0X2hhc2giOiItdUR6TFBDSEJBbndWXzFScDk3Y0lBIiwiYXVkIjoiZm9vIiwiZXhwIjoxNTI0MDQzNTI0LCJpYXQiOjE1MjQwMzk5MjQsImlzcyI6Imh0dHBzOi8vb3AucGFudmEubWUifQ.vYx-xWwBw82B_bfi9fyj1JfdTyuCLs24k7ccRkctJJzwofOz6ZAVbvm84J9ihkSJEpu4unrH1_S7CuasWMX1j_o7rsjaxWdZwXN-P0sGYzV2JkMXZRSKcvn9A5FppXS4N_MgIbXFDluRn7HSzPfHF7kzjQ9MsiRV1a5YjQjb0yVq8Ntg-GP_7-HJcc494zWDQcKJBV8finr2jDvGMiANc63yjcePK44to-1ybpDzuy3bK4BX0rEqcZ2vs-IiGynHp1RnJsVMqu_j094J5vFLPgvUzDWZatLeufe6uOgLJh6ZIFbG6Cjx-DByzpzl9sq3Hk5yGAen1Y1L1pS9nI8qhg

(2)
https://jwt.io/#access_token=MzgxY2NjMGQtYzhhMC00MGUwLWIxMzAtMTQ0ZDMwNDk0MTEzxMYyRIxwvj0g_mmTJui6rbwwSIz_0n46oHj6MNAQ-mtDsF7HPOpHYCGdTUkJwPNrQJdb-Wb5_G1gqwR-w1SpSA&expires_in=3600&token_type=Bearer&id_token=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InIxTGtiQm8zOTI1UmIyWkZGckt5VTNNVmV4OVQyODE3S3gwdmJpNmlfS2MifQ.eyJzdWIiOiJjOTUyNjUyNi05M2QxLTQzN2YtYTE0ZS1jMmFmODU2ODhkNTYiLCJub25jZSI6ImZvbyIsInNpZCI6IjU5MDQzNjlmLTNlNDQtNDc3Mi05ODY5LTM4ZWMwNmVmYThmNiIsImF0X2hhc2giOiJmbHZRTmlJYWlwdGU1Y3lNNUdZeXBBIiwiYXVkIjoiZm9vIiwiZXhwIjoxNTI0MDQ0ODU2LCJpYXQiOjE1MjQwNDEyNTYsImlzcyI6Imh0dHBzOi8vb3AucGFudmEubWUifQ.P0KTFShKSmHE4vlHFtMntUED7HwnxAe4GI1RcUuAP7FRNnhUxHFNKkg2JiG6vCTM0LOgiYdm9GSzwR4ZYLdVcHJ5kqf8cbqsrh1qiFf8PyBydwhray4wbhtvGaOsQsNJwXPE9TtqDyrirho1budfQ6sBbFU3aOnVQoyL1M143Ly-JaMl3gZVFHYphRu-NbMDPgUxh4UQosCTrbDvLOQBrufqt5kbV7SWJ1ejJc8cIzNLrsSBWOJFWxZ3u_GgyiDMhQSrsTHWu46ybtjZhIV6Hm-Xh74qjiOPqZyajeDYXx51hqhctSIZ0t2uwpNckE8RLTsycGtWYunet5T6KTaG-g
```

suggestion: A great addition would be to show buttons for each found JWT token in the parameters and switch between them, for instance when access_token is a jwt and id_token was returned too.