### PR TITLE
fix fragment callback parsing, parse other possible tokens

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -122,7 +122,7 @@ function regexp(body, flag) {
   return new RegExp("[?&#]" + body + "(?:=([^&#]*)|&|#|$)", flag);
 }
 
-const tokenRegexp = regexp('((?:id_|access_)?token)', 'g');
+const tokenRegexp = regexp('((?:id_|access_)?token|value)', 'g');
 
 export function getTokensFromLocation() {
   const { href } = window.location;

--- a/src/website/index.js
+++ b/src/website/index.js
@@ -5,7 +5,7 @@ import { setupTokenEditor, setTokenEditorValue } from '../editor';
 import { setupJwtCounter } from './counter.js';
 import { setupSmoothScrolling } from './smooth-scrolling.js';
 import { setupHighlighting } from './highlighting.js';
-import { getParameterByName } from '../utils.js';
+import { getParameterByName, getTokensFromLocation } from '../utils.js';
 import { isChrome, isFirefox } from './utils.js';
 import { setupShareJwtButton } from '../share-button.js';
 import { 
@@ -24,18 +24,17 @@ function parseLocationQuery() {
   const publicKey = getParameterByName('publicKey');
   const value = getParameterByName('value');
   const token = getParameterByName('token');
+  const { id_token, access_token } = getTokensFromLocation();
 
   let scroll = false;
   if(publicKey) {
     publicKeyTextArea.value = publicKey;
     scroll = true;
   }
-  if(value) {
-    setTokenEditorValue(value);
-    scroll = true;
-  }
-  if(token) {
-    setTokenEditorValue(token);
+
+  const val = value || token || id_token || access_token;
+  if(val) {
+    setTokenEditorValue(val);
     scroll = true;
   }
 

--- a/src/website/index.js
+++ b/src/website/index.js
@@ -22,9 +22,7 @@ import {
 
 function parseLocationQuery() {
   const publicKey = getParameterByName('publicKey');
-  const value = getParameterByName('value');
-  const token = getParameterByName('token');
-  const { id_token, access_token } = getTokensFromLocation();
+  const { id_token, access_token, value, token } = getTokensFromLocation();
 
   let scroll = false;
   if(publicKey) {

--- a/test/functional/editor.js
+++ b/test/functional/editor.js
@@ -31,6 +31,23 @@ describe('Editor', function() {
     await this.page.waitFor(3000);
     expect(await this.page.$eval('#debugger-io', isVisible)).to.be.true;    
   });
+  
+  const token = 'eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.';
+  ['token', 'value', 'id_token', 'access_token'].forEach((key) => {
+    [
+      `/?${key}=${token}`,
+      `/#${key}=${token}`,
+      `/?foo=bar&${key}=${token}`,
+      `/#foo=bar&${key}=${token}`,
+    ].forEach((structure, i) => {
+      it(`Should parse ${key} from window.location.href [${i}]`, async function () {
+        await this.page.goto(`http://localhost:8000${structure}${key}${i}`);
+        expect(await this.page.evaluate(() => {
+          return window.test.tokenEditor.getValue();
+        })).to.equal(`${token}${key}${i}`);
+      });
+    })
+  });
 
   it('HS256 should be selected by default', async function() {
     const selected = await this.page.$eval('#algorithm-select', select => {

--- a/test/functional/editor.js
+++ b/test/functional/editor.js
@@ -31,23 +31,6 @@ describe('Editor', function() {
     await this.page.waitFor(3000);
     expect(await this.page.$eval('#debugger-io', isVisible)).to.be.true;    
   });
-  
-  const token = 'eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.';
-  ['token', 'value', 'id_token', 'access_token'].forEach((key) => {
-    [
-      `/?${key}=${token}`,
-      `/#${key}=${token}`,
-      `/?foo=bar&${key}=${token}`,
-      `/#foo=bar&${key}=${token}`,
-    ].forEach((structure, i) => {
-      it(`Should parse ${key} from window.location.href [${i}]`, async function () {
-        await this.page.goto(`http://localhost:8000${structure}${key}${i}`);
-        expect(await this.page.evaluate(() => {
-          return window.test.tokenEditor.getValue();
-        })).to.equal(`${token}${key}${i}`);
-      });
-    })
-  });
 
   it('HS256 should be selected by default', async function() {
     const selected = await this.page.$eval('#algorithm-select', select => {
@@ -1167,5 +1150,24 @@ describe('Editor', function() {
         expect(destPubKey).to.equal(defaultTokens['rs256'].publicKey);
       }
     );
+  });
+  
+  describe('parsing tokens from window.location.href', () => {
+    const token = 'eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.';
+    ['token', 'value', 'id_token', 'access_token'].forEach((key) => {
+      [
+        `/?${key}=${token}`,
+        `/#${key}=${token}`,
+        `/?foo=bar&${key}=${token}`,
+        `/#foo=bar&${key}=${token}`,
+      ].forEach((structure, i) => {
+        it(`Should parse ${key} from window.location.href [${i}]`, async function () {
+          await this.page.goto(`http://localhost:8000${structure}${key}${i}`);
+          expect(await this.page.evaluate(() => {
+            return window.test.tokenEditor.getValue();
+          })).to.equal(`${token}${key}${i}`);
+        });
+      })
+    });
   });
 });


### PR DESCRIPTION
(rebased #304 on top of stage-6 refactor)

A common pattern for OAuth2 and OIDC callback testing is registering jwt.io as a redirect_uri to show the claims from an id_token or jwt formatted access_token immediately.

- fix parsing locations where the token might be the first parameter with no `?` at the beginning (response_mode=fragment) (1)
- parse id_token and access_token in addition to value and token (2)

```
(1)
https://jwt.io/#token=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InIxTGtiQm8zOTI1UmIyWkZGckt5VTNNVmV4OVQyODE3S3gwdmJpNmlfS2MifQ.eyJzdWIiOiJjOTUyNjUyNi05M2QxLTQzN2YtYTE0ZS1jMmFmODU2ODhkNTYiLCJub25jZSI6ImZvbyIsInNpZCI6IjU5MDQzNjlmLTNlNDQtNDc3Mi05ODY5LTM4ZWMwNmVmYThmNiIsImF0X2hhc2giOiItdUR6TFBDSEJBbndWXzFScDk3Y0lBIiwiYXVkIjoiZm9vIiwiZXhwIjoxNTI0MDQzNTI0LCJpYXQiOjE1MjQwMzk5MjQsImlzcyI6Imh0dHBzOi8vb3AucGFudmEubWUifQ.vYx-xWwBw82B_bfi9fyj1JfdTyuCLs24k7ccRkctJJzwofOz6ZAVbvm84J9ihkSJEpu4unrH1_S7CuasWMX1j_o7rsjaxWdZwXN-P0sGYzV2JkMXZRSKcvn9A5FppXS4N_MgIbXFDluRn7HSzPfHF7kzjQ9MsiRV1a5YjQjb0yVq8Ntg-GP_7-HJcc494zWDQcKJBV8finr2jDvGMiANc63yjcePK44to-1ybpDzuy3bK4BX0rEqcZ2vs-IiGynHp1RnJsVMqu_j094J5vFLPgvUzDWZatLeufe6uOgLJh6ZIFbG6Cjx-DByzpzl9sq3Hk5yGAen1Y1L1pS9nI8qhg

(2)
https://jwt.io/#access_token=MzgxY2NjMGQtYzhhMC00MGUwLWIxMzAtMTQ0ZDMwNDk0MTEzxMYyRIxwvj0g_mmTJui6rbwwSIz_0n46oHj6MNAQ-mtDsF7HPOpHYCGdTUkJwPNrQJdb-Wb5_G1gqwR-w1SpSA&expires_in=3600&token_type=Bearer&id_token=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InIxTGtiQm8zOTI1UmIyWkZGckt5VTNNVmV4OVQyODE3S3gwdmJpNmlfS2MifQ.eyJzdWIiOiJjOTUyNjUyNi05M2QxLTQzN2YtYTE0ZS1jMmFmODU2ODhkNTYiLCJub25jZSI6ImZvbyIsInNpZCI6IjU5MDQzNjlmLTNlNDQtNDc3Mi05ODY5LTM4ZWMwNmVmYThmNiIsImF0X2hhc2giOiJmbHZRTmlJYWlwdGU1Y3lNNUdZeXBBIiwiYXVkIjoiZm9vIiwiZXhwIjoxNTI0MDQ0ODU2LCJpYXQiOjE1MjQwNDEyNTYsImlzcyI6Imh0dHBzOi8vb3AucGFudmEubWUifQ.P0KTFShKSmHE4vlHFtMntUED7HwnxAe4GI1RcUuAP7FRNnhUxHFNKkg2JiG6vCTM0LOgiYdm9GSzwR4ZYLdVcHJ5kqf8cbqsrh1qiFf8PyBydwhray4wbhtvGaOsQsNJwXPE9TtqDyrirho1budfQ6sBbFU3aOnVQoyL1M143Ly-JaMl3gZVFHYphRu-NbMDPgUxh4UQosCTrbDvLOQBrufqt5kbV7SWJ1ejJc8cIzNLrsSBWOJFWxZ3u_GgyiDMhQSrsTHWu46ybtjZhIV6Hm-Xh74qjiOPqZyajeDYXx51hqhctSIZ0t2uwpNckE8RLTsycGtWYunet5T6KTaG-g
```

suggestion: A great addition would be to show buttons for each found JWT token in the parameters and switch between them, for instance when access_token is a jwt and id_token was returned too.