### PR TITLE
add `sid` tooltip

### DIFF
--- a/src/strings.js
+++ b/src/strings.js
@@ -25,7 +25,8 @@ export default {
       zip: 'Compression algorithm',
       kty: 'Key type',
       use: 'Intended use of key: "sig" or "enc" (other values accepted)',
-      key_ops: 'Intended operations for this key'      
+      key_ops: 'Intended operations for this key'      ,
+      sid: 'Session ID (String identifier for a Session)'
     }
   },
   extension: {


### PR DESCRIPTION
`sid` ID Token/Logout Token claim used in the session management/logout family of specs

- https://openid.net/specs/openid-connect-session-1_0.html
- https://openid.net/specs/openid-connect-frontchannel-1_0.html
- https://openid.net/specs/openid-connect-backchannel-1_0.html