### PR TITLE
Update blog post link

### DIFF
--- a/views/website/libraries.pug
+++ b/views/website/libraries.pug
@@ -18,7 +18,7 @@ section#libraries-io.libraries-jwt
     .warning
       b Warning:
       |  Critical vulnerabilities in JSON Web Token libraries with asymmetric keys.
-      a(href='https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/')
+      a(href='https://auth0.com/blog/critical-vulnerabilities-in-json-web-token-libraries/')
         | Learn more
 
         svg(height='48', viewbox='0 0 48 48', width='48', xmlns='http://www.w3.org/2000/svg')

--- a/views/website/libraries/template.pug
+++ b/views/website/libraries/template.pug
@@ -6,7 +6,7 @@ article(data-accordion, class=`accordion ${lang.uniqueClass}`)
     if lib.minimumVersion
       .version
         p Minimum Version #{lib.minimumVersion}
-          a(href='https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/', target='_blank')
+          a(href='https://auth0.com/blog/critical-vulnerabilities-in-json-web-token-libraries/', target='_blank')
             img(src='img/ico_question.svg')    
     div(class={ 'panel-body': true, mversion: !!lib.minimumVersion })
       .column


### PR DESCRIPTION
Currently, the blog post link throws a 404. Seems like the format has changed. The link is now in the `auth0.com/blog/post-name-here` format.