### PR TITLE
Ensured the JWKS-lookup works with iss properties that are not

### DIFF
--- a/src/editor/public-key-download.js
+++ b/src/editor/public-key-download.js
@@ -67,8 +67,8 @@ export function downloadPublicKeyIfPossible(decodedToken) {
     } else if(header.jwk) {
       resolve(getKeyFromX5Claims(header.jwk));
     } else if(header.kid && payload.iss) {
-      //Auth0-specific scheme
-      const url = payload.iss + '.well-known/jwks.json';
+      const slashTerminatedIss = payload.iss.replace(/\/$/, "") + "/";
+      const url = slashTerminatedIss + '.well-known/jwks.json';
       resolve(getKeyFromJwkKeySetUrl(header.kid, url));
     } else {
       reject('No details about key');

--- a/test/unit/editor/public-key-download.js
+++ b/test/unit/editor/public-key-download.js
@@ -60,6 +60,31 @@ describe('Public key downloader', function() {
       }).should.notify(done);    
   });
 
+  it('Can find keys for non-slash-terminated iss', function(done) {
+    const decodedToken = _.defaultsDeep({}, decodedBaseToken, {
+      header: {
+        kid: 1
+      },
+      payload: {
+        iss: "https://not.slash.terminated"
+      }
+    });
+
+    const httpGetStub = sinon.stub().resolves(JSON.stringify(jwks));
+    const downloadPublicKeyIfPossible = publicKeyDownloadInjector({
+      '../utils.js': {
+        httpGet: httpGetStub
+      }
+    }).downloadPublicKeyIfPossible;
+
+    downloadPublicKeyIfPossible(decodedToken)
+      .should.eventually.include(jwks.keys[0].x5c[0])
+      .then(() => {
+        httpGetStub.should.have.been
+                   .calledWith('https://not.slash.terminated/.well-known/jwks.json');
+      }).should.notify(done);    
+  });
+
   it('Finds keys in jwk header claim', function(done) {
     const decodedToken = _.defaultsDeep({}, decodedBaseToken, {
       header: {


### PR DESCRIPTION
slash-terminated.

Not all JWT issuers use slash-terminated `iss` values - this PR makes the signature validation logic work with those as well.