### PR TITLE
Added a dotNet library Trivial.

### DIFF
--- a/views/website/libraries/0-.NET.json
+++ b/views/website/libraries/0-.NET.json
@@ -31,12 +31,9 @@
       },
       "authorUrl": "https://www.microsoft.com",
       "authorName": "Microsoft",
-      "gitHubRepoPath":
-        "AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet",
-      "repoUrl":
-        "https://github.com/MSOpenTech/azure-activedirectory-identitymodel-extensions-for-dotnet",
-      "installCommandHtml":
-        "Install-Package<br><a href=\"https://www.nuget.org/packages/System.IdentityModel.Tokens.Jwt/\">System.IdentityModel.Tokens.Jwt</a>"
+      "gitHubRepoPath": "AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet",
+      "repoUrl": "https://github.com/MSOpenTech/azure-activedirectory-identitymodel-extensions-for-dotnet",
+      "installCommandHtml": "Install-Package<br><a href=\"https://www.nuget.org/packages/System.IdentityModel.Tokens.Jwt/\">System.IdentityModel.Tokens.Jwt</a>"
     },
     {
       "minimumVersion": null,
@@ -67,8 +64,7 @@
       "authorName": "DV",
       "gitHubRepoPath": "dvsekhvalnov/jose-jwt",
       "repoUrl": "https://github.com/dvsekhvalnov/jose-jwt",
-      "installCommandHtml":
-        "Install-Package<br><a href=\"http://www.nuget.org/packages/jose-jwt/\">jose-jwt</a>"
+      "installCommandHtml": "Install-Package<br><a href=\"http://www.nuget.org/packages/jose-jwt/\">jose-jwt</a>"
     },
     {
       "minimumVersion": null,
@@ -96,8 +92,38 @@
       "authorName": "DV",
       "gitHubRepoPath": "dvsekhvalnov/jose-rt",
       "repoUrl": "https://github.com/dvsekhvalnov/jose-rt",
-      "installCommandHtml":
-        "Install-Package<br><a href=\"http://www.nuget.org/packages/jose-rt/\">jose-rt</a>"
+      "installCommandHtml": "Install-Package<br><a href=\"http://www.nuget.org/packages/jose-rt/\">jose-rt</a>"
+    },
+    {
+      "minimumVersion": null,
+      "support": {
+        "sign": true,
+        "verify": true,
+        "iss": true,
+        "sub": true,
+        "aud": true,
+        "exp": true,
+        "nbf": true,
+        "iat": true,
+        "jti": true,
+        "hs256": true,
+        "hs384": true,
+        "hs512": true,
+        "rs256": true,
+        "rs384": true,
+        "rs512": true,
+        "es256": false,
+        "es384": false,
+        "es512": false,
+        "ps256": false,
+        "ps384": false,
+        "ps512": false
+      },
+      "authorUrl": "https://github.com/nuscien/trivial/wiki/oauth",
+      "authorName": "Kingcean Tuan",
+      "gitHubRepoPath": "nuscien/trivial",
+      "repoUrl": "https://github.com/nuscien/trivial",
+      "installCommandHtml": "Install-Package<br><a href=\"https://www.nuget.org/packages/Trivial\">Trivial</a>"
     }
   ]
 }


### PR DESCRIPTION
Add a .NET library with JWT supports into the list. The name is [Trivial](https://www.nuget.org/packages/Trivial). The features are following, under its namespace `Trivial.Security`. 

- Parser & verify.
- Builder & sign.
- Full JWT payload fields supports.
- Customized JWT payload supports by generic type.
- Built-in signature algorithms including HS512, HS384, HS256, RS512, RS384 and RS256. And customized sign/verify algorithm supported.

The introduction link is following.

https://github.com/nuscien/trivial/wiki/oauth#jwt