### PR TITLE
Authlib supports PS256, PS384, and PS512

### DIFF
--- a/views/website/libraries/1-Python.json
+++ b/views/website/libraries/1-Python.json
@@ -118,7 +118,10 @@
         "rs512": true,
         "es256": true,
         "es384": true,
-        "es512": true
+        "es512": true,
+        "ps256": true,
+        "ps384": true,
+        "ps512": true
       },
       "authorUrl": "https://github.com/lepture",
       "authorName": "Hsiaoming Yang",


### PR DESCRIPTION
Mark support of PS256, PS384, and PS512 for Authlib.