### PR TITLE
fix: first populate input, then verify signatures

### DIFF
--- a/src/website/index.js
+++ b/src/website/index.js
@@ -39,12 +39,12 @@ function parseLocationQuery() {
     if (token) {
       metrics.track("token-in-url", { type: key });
 
-      setTokenEditorValue(token);
-
       if (locSearch.publicKey || locHash.publicKey) {
         metrics.track("pubkey-in-url");
         publicKeyTextArea.value = locSearch.publicKey || locHash.publicKey;
       }
+
+      setTokenEditorValue(token);
 
       debuggerSection.scrollIntoView(true);
 


### PR DESCRIPTION
This PR makes it so that if both key and token are part of the URL the tool first populates the input and then calls to validate the tokens.

Fixes #351 