### PR TITLE
fix: dont validate ill-formed tokens (but still debug them)

### DIFF
--- a/src/editor/utils.js
+++ b/src/editor/utils.js
@@ -54,26 +54,6 @@ export function isString(value) {
   return typeof value === 'string' || value instanceof String;
 }
 
-function getBase64Format(token) {
-  try {
-    function getFormat(str) {
-      if(jwt.isValidBase64String(str, true)) {
-        return 'base64url';
-      } else if(jwt.isValidBase64String(str, false)) {
-        return 'base64';
-      } else {
-        return 'invalid';
-      }
-    }
-
-    const formats = token.split('.').map(getFormat);
-    return formats.every(r => r === formats[0]) ?
-      formats[0] : 'invalid';
-  } catch(e) {
-    return 'invalid';
-  }
-}
-
 function getRegisteredClaims(payload) {
   const result = [];
 
@@ -125,7 +105,6 @@ export function getSafeTokenInfo(token) {
       Object.assign(result, {
         decodedWithErrors: decoded.errors,
         encodedSize: token.length,
-        base64Format: getBase64Format(token),
         header: {
           alg: decoded.header.alg,
         },

--- a/test/unit/editor/jwt.js
+++ b/test/unit/editor/jwt.js
@@ -220,16 +220,13 @@ describe('JWT', function() {
 
     it('detects valid Base64 and Base64URL strings', function() {
       data.forEach(d => {
-        jwt.isValidBase64String(d.b64, false).should.be.true;
-        jwt.isValidBase64String(d.b64u, false).should.be.true;
         jwt.isValidBase64String(d.b64u).should.be.true;
-        jwt.isValidBase64String(d.b64u, true).should.be.true;
       });
     });
 
     it('fails on invalid Base64 and Base64 URL strings', function() {
       data.forEach(d => {
-        if(d.b64.match(/[\+\/]/)) {
+        if(d.b64.match(/[\+\/=]/)) {
           jwt.isValidBase64String(d.b64, true).should.be.false;
         }
       });


### PR DESCRIPTION
This PR renders often used argument to JWT library maintainers asking to validate ill-formed JWTs (ones that don't have stripped `=` padding from base64url) moot.

Not validating such JWTs also aids interoperability as implementers will not be able to validate these incorrect JWTs.

https://tools.ietf.org/html/rfc7515#section-2

```
These terms are defined by this specification:

...

Base64url Encoding
      Base64 encoding using the URL- and filename-safe character set
      defined in Section 5 of RFC 4648 [RFC4648], with all trailing '='
      characters omitted (as permitted by Section 3.2) and without the
      inclusion of any line breaks, whitespace, or other additional
      characters.  Note that the base64url encoding of the empty octet
      sequence is the empty string.  (See Appendix C for notes on
      implementing base64url encoding without padding.)
```

There's no ambiguity, also all example Figures as well as the ["JOSE cookbook"](https://tools.ietf.org/html/rfc7520) obviously don't show any padding.