### PR TITLE
Update that firebase/php-jwt now supports ES256.

### DIFF
--- a/views/website/libraries/24-PHP.json
+++ b/views/website/libraries/24-PHP.json
@@ -22,7 +22,7 @@
         "rs256": true,
         "rs384": true,
         "rs512": true,
-        "es256": false,
+        "es256": true,
         "es384": false,
         "es512": false,
         "ps256": false,


### PR DESCRIPTION
Support was added in https://github.com/firebase/php-jwt/pull/239.