### PR TITLE
Add rib/jsonwebtokens to Rust libraries

### DIFF
--- a/views/website/libraries/13-Rust.json
+++ b/views/website/libraries/13-Rust.json
@@ -96,6 +96,37 @@
       "gitHubRepoPath": "lawliet89/biscuit",
       "repoUrl": "https://github.com/lawliet89/biscuit",
       "installCommandHtml": "Cargo.toml: biscuit = \"*\""
+    },
+    {
+      "minimumVersion": null,
+      "support": {
+        "sign": true,
+        "verify": true,
+        "iss": true,
+        "sub": true,
+        "aud": true,
+        "exp": true,
+        "nbf": true,
+        "iat": true,
+        "jti": false,
+        "hs256": true,
+        "hs384": true,
+        "hs512": true,
+        "rs256": true,
+        "rs384": true,
+        "rs512": true,
+        "es256": true,
+        "es384": true,
+        "es512": false,
+        "ps256": true,
+        "ps384": true,
+        "ps512": true
+      },
+      "authorUrl": "https://github.com/rib",
+      "authorName": "Robert Bragg",
+      "gitHubRepoPath": "rib/jsonwebtokens",
+      "repoUrl": "https://github.com/rib/jsonwebtokens",
+      "installCommandHtml": "Cargo.toml: jsonwebtokens = \"*\""
     }
   ]
 }


### PR DESCRIPTION
Originally based on [Keats/jsonwebtoken](https://github.com/Keats/jsonwebtoken) this project evolved from a few minor changes into a full re-design to best suit the use cases I have (including implementing https://crates.io/crates/jsonwebtokens-cognito).

I did a fairly broad survey of implementations across different languages when designing this and hope it strikes a practical balance between ergonomics, type safety and access to lower-level details. Hopefully it can be of use to others too.
