### PR TITLE
feat: es256k tick

### DIFF
--- a/views/website/libraries/1-Python.json
+++ b/views/website/libraries/1-Python.json
@@ -90,7 +90,8 @@
         "ps256": true,
         "ps384": true,
         "ps512": true,
-        "eddsa": true
+        "eddsa": true,
+        "es256k": true
       },
       "authorUrl": "https://github.com/simo5",
       "authorName": "Simo Sorce",

--- a/views/website/libraries/2-Node.js.json
+++ b/views/website/libraries/2-Node.js.json
@@ -28,7 +28,8 @@
         "ps256": true,
         "ps384": true,
         "ps512": true,
-        "eddsa": false
+        "eddsa": false,
+        "es256k": false
       },
       "authorUrl": "https://github.com/auth0",
       "authorName": "Auth0",
@@ -60,7 +61,8 @@
         "ps256": true,
         "ps384": true,
         "ps512": true,
-        "eddsa": true
+        "eddsa": true,
+        "es256k": true
       },
       "authorUrl": "https://github.com/panva",
       "authorName": "Filip Skokan",

--- a/views/website/libraries/24-PHP.json
+++ b/views/website/libraries/24-PHP.json
@@ -120,7 +120,8 @@
         "es512": true,
         "ps256": true,
         "ps384": true,
-        "ps512": true
+        "ps512": true,
+        "es256k": false
       },
       "authorUrl": "https://github.com/Spomky-Labs/jose",
       "authorName": "Spomky",
@@ -182,8 +183,9 @@
         "es512": true,
         "ps256": true,
         "ps384": true,
-        "ps512": true, 
-        "eddsa": true
+        "ps512": true,
+        "eddsa": true,
+        "es256k": true
       },
       "authorUrl": "https://github.com/Spomky",
       "authorName": "Spomky",

--- a/views/website/libraries/4-JavaScript.json
+++ b/views/website/libraries/4-JavaScript.json
@@ -87,7 +87,8 @@
         "ps256": true,
         "ps384": true,
         "ps512": true,
-        "eddsa": false
+        "eddsa": false,
+        "es256k": false
       },
       "authorUrl": "https://github.com/cisco",
       "authorName": "Cisco Systems",

--- a/views/website/libraries/support/get-libs-data.js
+++ b/views/website/libraries/support/get-libs-data.js
@@ -48,9 +48,10 @@ function getLibs() {
       }
 
       orderedKeys = ['hs256', 'hs384', 'hs512',
-                    'rs256', 'rs384', 'rs512',
-                    'es256', 'es384', 'es512'
-                    'ps256', 'ps384', 'ps512', 'eddsa', 'es256k'];
+                     'rs256', 'rs384', 'rs512',
+                     'es256', 'es256k', 'es384', 'es512',
+                     'ps256', 'ps384', 'ps512',
+                     'eddsa'];
 
       for(let i = 0; i < orderedKeys.length; ++i) {
         r.support[orderedKeys[i]] =

--- a/views/website/libraries/template.pug
+++ b/views/website/libraries/template.pug
@@ -55,6 +55,15 @@ article(data-accordion, class=`accordion ${lang.uniqueClass}`)
           i(class=lib.support.hs512 ? 'icon-budicon-500' : 'icon-budicon-501')
           | HS512
         p
+          i(class=lib.support.ps256 ? 'icon-budicon-500' : (lib.support.ps256 !== undefined ? 'icon-budicon-501' : 'icon-unknown'))
+          | PS256
+        p
+          i(class=lib.support.ps384 ? 'icon-budicon-500' : (lib.support.ps384 !== undefined ? 'icon-budicon-501' : 'icon-unknown'))
+          | PS384
+        p
+          i(class=lib.support.ps512 ? 'icon-budicon-500' : (lib.support.ps512 !== undefined ? 'icon-budicon-501' : 'icon-unknown'))
+          | PS512
+        p
           i(class=lib.support.rs256 ? 'icon-budicon-500' : 'icon-budicon-501')
           | RS256
         p
@@ -67,26 +76,17 @@ article(data-accordion, class=`accordion ${lang.uniqueClass}`)
           i(class=lib.support.es256 ? 'icon-budicon-500' : 'icon-budicon-501')
           | ES256
         p
+          i(class=lib.support.es256k ? 'icon-budicon-500' : (lib.support.es256k !== undefined ? 'icon-budicon-501' : 'icon-unknown'))
+          | ES256K
+        p
           i(class=lib.support.es384 ? 'icon-budicon-500' : 'icon-budicon-501')
           | ES384
         p
           i(class=lib.support.es512 ? 'icon-budicon-500' : 'icon-budicon-501')
           | ES512
         p
-          i(class=lib.support.ps256 ? 'icon-budicon-500' : (lib.support.ps256 !== undefined ? 'icon-budicon-501' : 'icon-unknown'))
-          | PS256
-        p
-          i(class=lib.support.ps384 ? 'icon-budicon-500' : (lib.support.ps384 !== undefined ? 'icon-budicon-501' : 'icon-unknown'))
-          | PS384
-        p
-          i(class=lib.support.ps512 ? 'icon-budicon-500' : (lib.support.ps512 !== undefined ? 'icon-budicon-501' : 'icon-unknown'))
-          | PS512
-        p
           i(class=lib.support.eddsa ? 'icon-budicon-500' : (lib.support.eddsa !== undefined ? 'icon-budicon-501' : 'icon-unknown'))
           | EdDSA
-        p
-          i(class=lib.support.es256k ? 'icon-budicon-500' : (lib.support.es256k !== undefined ? 'icon-budicon-501' : 'icon-unknown'))
-          | ES256K
 
     .author-info
       .maintainer


### PR DESCRIPTION
The working group last call has [ended](https://mailarchive.ietf.org/arch/msg/cose/J_8RWG5Tbe0stvTlfY6GJ9LpX5c) for the specification that defines `ES256K` as a JWS signing algorithm to be used with EC keys using the `secp256k1` curve.

This PR adds the algorithm to our json schema and displays the tick on the website. 

(it also moves PS before RS for two reasons - 1) PS is preferred over RS, 2) there was a gap between them and they're kind of the same family).

~Note: I will move the PR out of draft once the specification is published as an immutable RFC.~ Update: Done based on the fact that the curve and algorithm got accepted to the JOSE registry. 

Closes #468
