### PR TITLE
Fix hyperlinks in Introduction page

### DIFF
--- a/views/website/introduction.pug
+++ b/views/website/introduction.pug
@@ -39,8 +39,8 @@ block content
           img(src='/img/logo.svg').logo
 
       nav.menu
-        a(href='/#debugger').scrollto Debugger
-        a(href='/#libraries').scrollto Libraries
+        a(href='/index.html#debugger-io').scrollto Debugger
+        a(href='/index.html#libraries').scrollto Libraries
         a(href='/introduction').active Introduction
         a(href='https://community.auth0.com', target='_blank') Ask
         a(href='http://swag.auth0.com/', target='_blank') Get a T-shirt!

--- a/views/website/introduction.pug
+++ b/views/website/introduction.pug
@@ -39,8 +39,8 @@ block content
           img(src='/img/logo.svg').logo
 
       nav.menu
-        a(href='/index.html#debugger-io').scrollto Debugger
-        a(href='/index.html#libraries').scrollto Libraries
+        a(href='/#debugger-io').scrollto Debugger
+        a(href='/#libraries-io').scrollto Libraries
         a(href='/introduction').active Introduction
         a(href='https://community.auth0.com', target='_blank') Ask
         a(href='http://swag.auth0.com/', target='_blank') Get a T-shirt!

--- a/views/website/md/introduction.md
+++ b/views/website/md/introduction.md
@@ -88,7 +88,7 @@ The output is three Base64-URL strings separated by dots that can be easily pass
 The following shows a JWT that has the previous header and payload encoded, and it is signed with a secret.
 ![Encoded JWT](https://cdn.auth0.com/content/jwt/encoded-jwt3.png)
 
-If you want to play with JWT and put these concepts into practice, you can use [jwt.io Debugger](http://jwt.io) to decode, verify, and generate JWTs.
+If you want to play with JWT and put these concepts into practice, you can use [jwt.io Debugger](https://jwt.io/index.html#debugger-io) to decode, verify, and generate JWTs.
 
 ![JWT.io Debugger](https://cdn.auth0.com/blog/legacy-app-auth/legacy-app-auth-5.png)
 

--- a/views/website/md/introduction.md
+++ b/views/website/md/introduction.md
@@ -88,7 +88,7 @@ The output is three Base64-URL strings separated by dots that can be easily pass
 The following shows a JWT that has the previous header and payload encoded, and it is signed with a secret.
 ![Encoded JWT](https://cdn.auth0.com/content/jwt/encoded-jwt3.png)
 
-If you want to play with JWT and put these concepts into practice, you can use [jwt.io Debugger](https://jwt.io/index.html#debugger-io) to decode, verify, and generate JWTs.
+If you want to play with JWT and put these concepts into practice, you can use [jwt.io Debugger](https://jwt.io/#debugger-io) to decode, verify, and generate JWTs.
 
 ![JWT.io Debugger](https://cdn.auth0.com/blog/legacy-app-auth/legacy-app-auth-5.png)
 


### PR DESCRIPTION
This PR fixes the navigation links in the Introduction page (see: #432) (it now makes the page auto-scroll to the intended part of the page) and also corrects the link to the Debugger in a paragraph of the Introduction page.