### PR TITLE
Add JOSESwift to Swift libraries

### DIFF
--- a/views/website/libraries/19-Swift.json
+++ b/views/website/libraries/19-Swift.json
@@ -129,6 +129,37 @@
       "repoUrl": "https://github.com/IBM-Swift/Swift-JWT",
       "installCommandHtml":
         ".package(url:\"https://github.com/IBM-Swift/Swift-JWT\", from: \"3.5.0\")"
+    },
+    {
+      "minimumVersion": null,
+      "support": {
+        "sign": true,
+        "verify": true,
+        "iss": false,
+        "sub": false,
+        "aud": false,
+        "exp": false,
+        "nbf": false,
+        "iat": false,
+        "jti": false,
+        "hs256": false,
+        "hs384": false,
+        "hs512": false,
+        "rs256": true,
+        "rs384": true,
+        "rs512": true,
+        "es256": true,
+        "es384": true,
+        "es512": true,
+        "ps256": true,
+        "ps384": true,
+        "ps512": true
+      },
+      "authorUrl": "https://github.com/airsidemobile",
+      "authorName": "Airside",
+      "gitHubRepoPath": "airsidemobile/JOSESwift",
+      "repoUrl": "https://github.com/airsidemobile/JOSESwift",
+      "installCommandHtml": "pod 'JOSESwift'"
     }
   ]
 }


### PR DESCRIPTION
We maintain [JOSESwift](https://github.com/airsidemobile/joseswift), a Swift library for iOS covering both JWS and JWE formats.

We don't provide explicit helper functions to validate claims, but our library can trivially be used to create and validate signed (and encrypted) JWTs.

Would be cool if we could get onto the Swift list. Let me know if you have any questions.

Thanks for your great work in this space! 😎 