### PR TITLE
Update Artifact name for - io.jsonwebtoken-jjwt

### DIFF
--- a/views/website/libraries/3-Java.json
+++ b/views/website/libraries/3-Java.json
@@ -126,7 +126,7 @@
       "authorName": "Les Hazlewood",
       "gitHubRepoPath": "jwtk/jjwt",
       "repoUrl": "https://github.com/jwtk/jjwt",
-      "installCommandHtml": "maven: io.jsonwebtoken / jjwt / 0.9.0"
+      "installCommandHtml": "maven: io.jsonwebtoken / jjwt-root / 0.11.1"
     },
     {
       "minimumVersion": null,


### PR DESCRIPTION
Currently listed artifact version is 0.9.0. It looks like the repo owner changed the artifact name from jjwt to jjwt-root a while back: https://github.com/jwtk/jjwt/blob/master/pom.xml. There are newer versions to the jjwt-root artifact in maven. 
Before: https://mvnrepository.com/artifact/io.jsonwebtoken/jjwt
After: https://mvnrepository.com/artifact/io.jsonwebtoken/jjwt-root