### PR TITLE
Update 5-Perl.json

### DIFF
--- a/views/website/libraries/5-Perl.json
+++ b/views/website/libraries/5-Perl.json
@@ -27,7 +27,9 @@
         "es512": true,
         "ps256": true,
         "ps384": true,
-        "ps512": true
+        "ps512": true,
+        "es256k": true,
+        "EdDSA": true
       },
       "authorUrl": "https://github.com/DCIT",
       "authorName": "Karel Miko",


### PR DESCRIPTION
Perl Crypt::JWT distribution supports
ES256K since 0.027   2020-06-05
EdDSA since 0.026   2019-02-02