### PR TITLE
Add JWIT (go library)

### DIFF
--- a/views/website/libraries/9-Go.json
+++ b/views/website/libraries/9-Go.json
@@ -405,6 +405,39 @@
       "gitHubRepoPath": "cristalhq/jwt",
       "repoUrl": "https://github.com/cristalhq/jwt",
       "installCommandHtml": "go get github.com/cristalhq/jwt"
+    },
+    {
+      "minimumVersion": null,
+      "support": {
+        "sign": true,
+        "verify": true,
+        "iss": true,
+        "sub": false,
+        "aud": false,
+        "exp": true,
+        "nbf": true,
+        "iat": false,
+        "jti": false,
+        "hs256": false,
+        "hs384": false,
+        "hs512": false,
+        "rs256": true,
+        "rs384": true,
+        "rs512": true,
+        "es256": true,
+        "es384": true,
+        "es512": true,
+        "es256k": false,
+        "ps256": true,
+        "ps384": true,
+        "ps512": true,
+        "eddsa": true
+      },
+      "authorUrl": "https://github.com/gilbsgilbs",
+      "authorName": "gilbsgilbs",
+      "gitHubRepoPath": "gilbsgilbs/jwit",
+      "repoUrl": "https://github.com/gilbsgilbs/jwit",
+      "installCommandHtml": "go get <a href=\"https://pkg.go.dev/github.com/gilbsgilbs/jwit\">github.com/gilbsgilbs/jwit</a>"
     }
   ]
 }


### PR DESCRIPTION
:wave: This PR adds [JWIT](https://github.com/gilbsgilbs/jwit/), a tiny Go library I made that provides a high-level API to deal with JWKS and asymmetric JWTs.

It is not another re-implementation of the JWT/JWKS spec as it relies on [go-jose](https://github.com/square/go-jose) for JWT/JWKS parsing and validation, but as it is self-contained and doesn't require any "peer dependency" to work (i.e. go-jose is an implementation detail for the end-user), I think it makes sense to include it on this website. Let me know what you think.