### PR TITLE
feat: add "typ" (Type) Header Parameter check

### DIFF
--- a/views/website/libraries/2-Node.js.json
+++ b/views/website/libraries/2-Node.js.json
@@ -49,6 +49,7 @@
         "nbf": true,
         "iat": true,
         "jti": true,
+        "typ": true,
         "hs256": true,
         "hs384": true,
         "hs512": true,

--- a/views/website/libraries/4-JavaScript.json
+++ b/views/website/libraries/4-JavaScript.json
@@ -16,6 +16,7 @@
         "nbf": true,
         "iat": true,
         "jti": true,
+        "typ": true,
         "hs256": true,
         "hs384": true,
         "hs512": true,

--- a/views/website/libraries/support/get-libs-data.js
+++ b/views/website/libraries/support/get-libs-data.js
@@ -37,7 +37,7 @@ function getLibs() {
 
       let orderedKeys = ['sign', 'verify', 'iss',
                         'sub', 'aud', 'exp',
-                        'nbf', 'iat', 'jti'];
+                        'nbf', 'iat', 'jti', 'typ'];
 
       for(let i = 0; i < orderedKeys.length; ++i) {
         r.support[orderedKeys[i]] =

--- a/views/website/libraries/template.pug
+++ b/views/website/libraries/template.pug
@@ -44,6 +44,10 @@ article(data-accordion, class=`accordion ${lang.uniqueClass}`)
           i(class=lib.support.jti ? 'icon-budicon-500' : 'icon-budicon-501')
           code jti
           |  check
+        p
+          i(class=lib.support.typ ? 'icon-budicon-500' : (lib.support.typ !== undefined ? 'icon-budicon-501' : 'icon-unknown'))
+          code typ
+          |  check
       .column
         p
           i(class=lib.support.hs256 ? 'icon-budicon-500' : 'icon-budicon-501')


### PR DESCRIPTION
This PR adds a tick for the capability of a library to check a JWT "typ" (Type) Header Parameter. The current best practice for new JWT profiles is to explicitly type them. A recipient of a given JWT profiled token is then responsible for checking the token's type to be what they expect.

The "typ" check is similar to the existing "value" ones such as "iss" with, except that
- it expects the property in the protected header
- its value is case-insensitive
- it may or may not be prefixed with `application/`

Example implementation of such check is available [here](https://github.com/panva/jose/blob/v3.5.1/src/lib/jwt_claims_set.ts#L29-L36)