### PR TITLE
Add support for ES256K to l8w8jwt

### DIFF
--- a/views/website/libraries/20-C.json
+++ b/views/website/libraries/20-C.json
@@ -88,7 +88,8 @@
                 "es512": true,
                 "ps256": true,
                 "ps384": true,
-                "ps512": true
+                "ps512": true,
+                "es256k": true
             },
             "authorUrl": "https://github.com/GlitchedPolygons",
             "authorName": "Glitched Polygons",


### PR DESCRIPTION
Implemented l8w8jwt support for ES256K (see [pull-request 11](https://github.com/GlitchedPolygons/l8w8jwt/pull/11))

https://github.com/GlitchedPolygons/l8w8jwt