### PR TITLE
remove ? ticks for features added over 1 ago

### DIFF
--- a/views/website/libraries/template.pug
+++ b/views/website/libraries/template.pug
@@ -55,13 +55,13 @@ article(data-accordion, class=`accordion ${lang.uniqueClass}`)
           i(class=lib.support.hs512 ? 'icon-budicon-500' : 'icon-budicon-501')
           | HS512
         p
-          i(class=lib.support.ps256 ? 'icon-budicon-500' : (lib.support.ps256 !== undefined ? 'icon-budicon-501' : 'icon-unknown'))
+          i(class=lib.support.ps256 ? 'icon-budicon-500' : 'icon-budicon-501')
           | PS256
         p
-          i(class=lib.support.ps384 ? 'icon-budicon-500' : (lib.support.ps384 !== undefined ? 'icon-budicon-501' : 'icon-unknown'))
+          i(class=lib.support.ps384 ? 'icon-budicon-500' : 'icon-budicon-501')
           | PS384
         p
-          i(class=lib.support.ps512 ? 'icon-budicon-500' : (lib.support.ps512 !== undefined ? 'icon-budicon-501' : 'icon-unknown'))
+          i(class=lib.support.ps512 ? 'icon-budicon-500' : 'icon-budicon-501')
           | PS512
         p
           i(class=lib.support.rs256 ? 'icon-budicon-500' : 'icon-budicon-501')
@@ -85,7 +85,7 @@ article(data-accordion, class=`accordion ${lang.uniqueClass}`)
           i(class=lib.support.es512 ? 'icon-budicon-500' : 'icon-budicon-501')
           | ES512
         p
-          i(class=lib.support.eddsa ? 'icon-budicon-500' : (lib.support.eddsa !== undefined ? 'icon-budicon-501' : 'icon-unknown'))
+          i(class=lib.support.eddsa ? 'icon-budicon-500' : 'icon-budicon-501')
           | EdDSA
 
     .author-info


### PR DESCRIPTION
This changes the `?` ticks to `x` for features we've added >= 1 year ago.

- [RSASSA-PSS](https://github.com/jsonwebtoken/jsonwebtoken.github.io/pull/373) Jan 2019
- [EdDSA](https://github.com/jsonwebtoken/jsonwebtoken.github.io/pull/391) Aug 2019

I'm keeping [ES256K](https://github.com/jsonwebtoken/jsonwebtoken.github.io/pull/445), Jun 2020, as-is.