### PR TITLE
Update 9-Go.json

### DIFF
--- a/views/website/libraries/9-Go.json
+++ b/views/website/libraries/9-Go.json
@@ -182,7 +182,8 @@
         "es512": true,
         "ps256": true,
         "ps384": true,
-        "ps512": true
+        "ps512": true,
+        "eddsa": true
       },
       "authorUrl": "https://github.com/lestrrat",
       "authorName": "lestrrat",


### PR DESCRIPTION
github.com/lestrrat-go/jwx supports EdDSA since v1.0.7 https://github.com/lestrrat-go/jwx/releases/tag/v1.0.7