### PR TITLE
Update 9-Go.json

### DIFF
--- a/views/website/libraries/9-Go.json
+++ b/views/website/libraries/9-Go.json
@@ -210,6 +210,7 @@
         "rs384": true,
         "rs512": true,
         "es256": true,
+        "es256k": true,
         "es384": true,
         "es512": true
       },


### PR DESCRIPTION
github.com/lestrrat-go/jwx supports es256k as of v1.1.3