### PR TITLE
Set es256k to true for rhonabwy

### DIFF
--- a/views/website/libraries/20-C.json
+++ b/views/website/libraries/20-C.json
@@ -156,7 +156,7 @@
                 "ps384": true,
                 "ps512": true,
                 "eddsa": true,
-                "es256k": false
+                "es256k": true
             },
             "authorUrl": "https://babelouest.github.io/",
             "authorName": "babelouest",


### PR DESCRIPTION
Sorry, there was a typo in the previous PR, rhonabwy does support es256k signatures