### PR TITLE
Remove es256k support from rhonabwy

### DIFF
--- a/views/website/libraries/20-C.json
+++ b/views/website/libraries/20-C.json
@@ -156,7 +156,7 @@
                 "ps384": true,
                 "ps512": true,
                 "eddsa": true,
-                "es256k": true
+                "es256k": false
             },
             "authorUrl": "https://babelouest.github.io/",
             "authorName": "babelouest",


### PR DESCRIPTION
After triple checking it, I found out that `es256k` signature support is not completely available in rhonabwy, since GnuTLS seems not to doesn't handle `secp256k1` at the moment.