### PR TITLE
A new home for `dgrijalva/jwt-go`

### DIFF
--- a/views/website/libraries/9-Go.json
+++ b/views/website/libraries/9-Go.json
@@ -14,7 +14,7 @@
         "aud": false,
         "exp": true,
         "nbf": true,
-        "iat": false,
+        "iat": true,
         "jti": false,
         "hs256": true,
         "hs384": true,
@@ -29,11 +29,11 @@
         "ps384": false,
         "ps512": false
       },
-      "authorUrl": "https://github.com/dgrijalva",
-      "authorName": "dgrijalva",
-      "gitHubRepoPath": "dgrijalva/jwt-go",
-      "repoUrl": "https://github.com/dgrijalva/jwt-go",
-      "installCommandHtml": "go get <a href=\"https://godoc.org/github.com/dgrijalva/jwt-go\">github.com/dgrijalva/jwt-go</a>"
+      "authorUrl": "https://github.com/golang-jwt",
+      "authorName": "golang-jwt",
+      "gitHubRepoPath": "golang-jwt/jwt",
+      "repoUrl": "https://github.com/golang-jwt/jwt",
+      "installCommandHtml": "go get <a href=\"https://pkg.go.dev/github.com/golang-jwt/jwt\">github.com/golang-jwt/jwt</a>"
     },
     {
       "minimumVersion": null,


### PR DESCRIPTION
As discussed in https://github.com/dgrijalva/jwt-go/issues/462, `dgrijalva/jwt-go` has been unmaintained for a while. A team of open source maintainers created a new org `golang-jwt` to provide a community-backed fork/clone of the original project, adhering to the original design ideas and following a backwards-compatible way forward in improving the library.

It would be very helpful to move as many people as possible over to the new home of the library, instead of linking to the old, unmaintained version, which also contains an unpatched minor security flaw concerning an audience check.

Furthermore, I am not quite sure what exactly the library needs to support to get a checkbox for `iss` and `aud` check, there are validation methods for them in the library, but optional. However `iat` is checked by default, so I added that.

