### PR TITLE
Updated golang-jwt feature set

### DIFF
--- a/views/website/libraries/9-Go.json
+++ b/views/website/libraries/9-Go.json
@@ -5,13 +5,13 @@
   "bgColor": "rgb(71, 182, 196)",
   "libs": [
     {
-      "minimumVersion": null,
+      "minimumVersion": "1.15",
       "support": {
         "sign": true,
         "verify": true,
         "iss": false,
         "sub": false,
-        "aud": false,
+        "aud": true,
         "exp": true,
         "nbf": true,
         "iat": true,
@@ -34,7 +34,7 @@
       "authorName": "golang-jwt",
       "gitHubRepoPath": "golang-jwt/jwt",
       "repoUrl": "https://github.com/golang-jwt/jwt",
-      "installCommandHtml": "go get <a href=\"https://pkg.go.dev/github.com/golang-jwt/jwt\">github.com/golang-jwt/jwt</a>"
+      "installCommandHtml": "go get <a href=\"https://pkg.go.dev/github.com/golang-jwt/jwt/v4\">github.com/golang-jwt/jwt/v4</a>"
     },
     {
       "minimumVersion": null,

--- a/views/website/libraries/9-Go.json
+++ b/views/website/libraries/9-Go.json
@@ -5,7 +5,7 @@
   "bgColor": "rgb(71, 182, 196)",
   "libs": [
     {
-      "minimumVersion": "1.15",
+      "minimumVersion": "v3.2.2",
       "support": {
         "sign": true,
         "verify": true,


### PR DESCRIPTION
* We just released v4, so this should be set as the default
* We require a minimum Go version of 1.15
* We do support `aud` verification.

Fixes https://github.com/golang-jwt/jwt/issues/65