### PR TITLE
Update Thalhammer/jwt-cpp

### DIFF
--- a/views/website/libraries/21-C++.json
+++ b/views/website/libraries/21-C++.json
@@ -48,6 +48,7 @@
         "nbf": true,
         "iat": true,
         "jti": true,
+        "typ": true,
         "hs256": true,
         "hs384": true,
         "hs512": true,
@@ -55,11 +56,13 @@
         "rs384": true,
         "rs512": true,
         "es256": true,
+        "es256k": true,
         "es384": true,
         "es512": true,
         "ps256": true,
         "ps384": true,
-        "ps512": true
+        "ps512": true,
+        "eddsa": true
       },
       "authorUrl": "https://github.com/Thalhammer",
       "authorName": "Dominik Thalhammer",


### PR DESCRIPTION
jwt-cpp has supported both eddsa and the "typ" check for quite some time now and just recently got official support for es256k.