### PR TITLE
Update language-schema.js to include typ field

### DIFF
--- a/views/website/libraries/support/language-schema.js
+++ b/views/website/libraries/support/language-schema.js
@@ -73,6 +73,7 @@ module.exports = {
               nbf: { type: 'boolean' },
               iat: { type: 'boolean' },
               jti: { type: 'boolean' },
+              typ: { type: 'boolean' },
               hs256: { type: 'boolean' },
               hs384: { type: 'boolean' },
               hs512: { type: 'boolean' },


### PR DESCRIPTION
The typ field is expected and in use by multiple libraries, yet it is missing in the schema.