### PR TITLE
fix: validate signatures regardless of JWT payloads

### DIFF
--- a/src/editor/jwt.js
+++ b/src/editor/jwt.js
@@ -138,19 +138,15 @@ export function decode(jwt) {
         if (!isValidBase64String(split[1])) {
             result.warnings.push(strings.warnings.payloadBase64Invalid);
         }
-        result.payload = JSON.parse(b64u.decode(split[1]));
-    } catch (e) {
-        result.errors = true;
-    }
+        result.payload = b64u.decode(split[1]);
+    } catch (e) {}
 
     try {
         if (!isValidJSON(b64u.decode(split[1]))) {
             result.warnings.push(strings.warnings.payloadInvalidJSON);
-            result.payload = b64u.decode(split[1])
         }
-    } catch (e) {
-        result.errors = true;
-    }
+        result.payload = JSON.parse(b64u.decode(split[1]))
+    } catch (e) {}
 
     return result;
 }


### PR DESCRIPTION
This PR makes it so that tokens that are not JWTs but plain JWS still get their signature verified.

e.g. [this token](https://jwt.io/#debugger-io?token=eyJhbGciOiJFUzI1NiJ9.bY9PSwMxEMW_ShgPvcR0F1ukYSnoQSx4Wmsv0kOaTN1I3C0zWaEUv3uTbY7Obf6833tzAc8MGppmwzwiiY_2bb0GCf3hCLperurq4XG1qCT8WtAXiOcTgv6ELsYT6_mcfwzFDk2InbKGHN_dmvvcJEzTPDnnox96E8Q2iTnR9xIsocM-ehPex8M32pjhx87TDonT9RTp5XXTijKQAtWXErOFqlQ9myLm8-exdwGzmJCHkSxup4RQFrIkBjuEkGwyWkJypnN-o3i0RTth_5sppWD_l-oK.ykP26UhcX74htggpqs-rgKXF0kjCfH0dXh7QdBQesBZsmsGt2etHphQp4HZc4o5wtR_nbelAjwYtAZflchO_7w&publicKey=%7B%22crv%22%3A%22P-256%22%2C%22x%22%3A%22ITarCiMjs-CAHFz3oYcE_W1OgsytVj3txxu_TLgy9YA%22%2C%22y%22%3A%22itqoXS2rIViccixwDyxvgeyH4SK60iUoONTLkjfqOq8%22%2C%22d%22%3A%22as2O04ylvgwKSrPi1lVwOx4BQO32tvYhRBufDvvrK98%22%2C%22kty%22%3A%22EC%22%7D) should produce a signature verified message, but currently doesn't.

Refs #560