### PR TITLE
Added functionality to decode jwt with jwt.io/{jwt}. Saves an extra s…

### DIFF
--- a/server.js
+++ b/server.js
@@ -36,6 +36,11 @@ app.get("/home", function(req, res) {
     res.redirect("/");
 });
 
+// Path routes to home if JWT format recognized.
+app.get("/ey*", function(req, res) {
+    res.render("index");
+});
+
 app.listen(process.env.PORT || 3000, function() {
     console.log("Started.");
 });

--- a/src/website/index.js
+++ b/src/website/index.js
@@ -45,10 +45,12 @@ function parseLocationQuery() {
     }
 }
 
+const checkForJWTInUrl = document.location.pathname.substr(1);
+
 // Initialization
 setupNavbar();
 setupSmoothScrolling();
-setupTokenEditor();
+setupTokenEditor(checkForJWTInUrl);
 parseLocationQuery();
 setupHighlighting();
 setupJwtCounter();


### PR DESCRIPTION
…tep in the JWT decode process. Had to add a path to server.js as well as modify a couple functions to check if the URL contains a JWT before falling back on the default tokens.