### PR TITLE
Add GDScript Library for Godot Engine

### DIFF
--- a/img/website/34.svg
+++ b/img/website/34.svg
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="1024" height="1024" id="svg3030" version="1.1" inkscape:version="0.92.1 r15371" sodipodi:docname="icon.svg" inkscape:export-filename="/home/akien/Projects/godot/godot.git/icon.png" inkscape:export-xdpi="24" inkscape:export-ydpi="24">
+  <defs id="defs3032"/>
+  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="0.35" inkscape:cx="707.24666" inkscape:cy="14.063809" inkscape:document-units="px" inkscape:current-layer="layer1" showgrid="false" inkscape:window-width="1920" inkscape:window-height="1011" inkscape:window-x="0" inkscape:window-y="0" inkscape:window-maximized="1"/>
+  <metadata id="metadata3035">
+    <rdf:RDF>
+      <cc:Work rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+        <dc:title/>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g inkscape:label="Layer 1" inkscape:groupmode="layer" id="layer1" transform="translate(0,-98.519719)">
+    <g id="g78" transform="matrix(4.162611,0,0,-4.162611,919.24059,771.67186)" style="stroke-width:0.32031175">
+      <path d="m 0,0 c 0,0 -0.325,1.994 -0.515,1.976 l -36.182,-3.491 c -2.879,-0.278 -5.115,-2.574 -5.317,-5.459 l -0.994,-14.247 -27.992,-1.997 -1.904,12.912 c -0.424,2.872 -2.932,5.037 -5.835,5.037 h -38.188 c -2.902,0 -5.41,-2.165 -5.834,-5.037 l -1.905,-12.912 -27.992,1.997 -0.994,14.247 c -0.202,2.886 -2.438,5.182 -5.317,5.46 l -36.2,3.49 c -0.187,0.018 -0.324,-1.978 -0.511,-1.978 l -0.049,-7.83 30.658,-4.944 1.004,-14.374 c 0.203,-2.91 2.551,-5.263 5.463,-5.472 l 38.551,-2.75 c 0.146,-0.01 0.29,-0.016 0.434,-0.016 2.897,0 5.401,2.166 5.825,5.038 l 1.959,13.286 h 28.005 l 1.959,-13.286 c 0.423,-2.871 2.93,-5.037 5.831,-5.037 0.142,0 0.284,0.005 0.423,0.015 l 38.556,2.75 c 2.911,0.209 5.26,2.562 5.463,5.472 l 1.003,14.374 30.645,4.966 z" style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.32031175" id="path80" inkscape:connector-curvature="0"/>
+    </g>
+    <g id="g82-3" transform="matrix(4.162611,0,0,-4.162611,104.69892,525.90697)" style="stroke-width:0.32031175">
+      <path d="m 0,0 v -47.514 -6.035 -5.492 c 0.108,-0.001 0.216,-0.005 0.323,-0.015 l 36.196,-3.49 c 1.896,-0.183 3.382,-1.709 3.514,-3.609 l 1.116,-15.978 31.574,-2.253 2.175,14.747 c 0.282,1.912 1.922,3.329 3.856,3.329 h 38.188 c 1.933,0 3.573,-1.417 3.855,-3.329 l 2.175,-14.747 31.575,2.253 1.115,15.978 c 0.133,1.9 1.618,3.425 3.514,3.609 l 36.182,3.49 c 0.107,0.01 0.214,0.014 0.322,0.015 v 4.711 l 0.015,0.005 V 0 h 0.134 c 4.795,6.12 9.232,12.569 13.487,19.449 -5.651,9.62 -12.575,18.217 -19.976,26.182 -6.864,-3.455 -13.531,-7.369 -19.828,-11.534 -3.151,3.132 -6.7,5.694 -10.186,8.372 -3.425,2.751 -7.285,4.768 -10.946,7.118 1.09,8.117 1.629,16.108 1.846,24.448 -9.446,4.754 -19.519,7.906 -29.708,10.17 -4.068,-6.837 -7.788,-14.241 -11.028,-21.479 -3.842,0.642 -7.702,0.88 -11.567,0.926 v 0.006 c -0.027,0 -0.052,-0.006 -0.075,-0.006 -0.024,0 -0.049,0.006 -0.073,0.006 V 63.652 C 93.903,63.606 90.046,63.368 86.203,62.726 82.965,69.964 79.247,77.368 75.173,84.205 64.989,81.941 54.915,78.789 45.47,74.035 45.686,65.695 46.225,57.704 47.318,49.587 43.65,47.237 39.795,45.22 36.369,42.469 32.888,39.791 29.333,37.229 26.181,34.097 19.884,38.262 13.219,42.176 6.353,45.631 -1.048,37.666 -7.968,29.069 -13.621,19.449 -9.368,12.569 -4.928,6.12 -0.134,0 Z" style="fill:#478cbf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.32031175" id="path84-6" inkscape:connector-curvature="0"/>
+    </g>
+    <g id="g86-7" transform="matrix(4.162611,0,0,-4.162611,784.07144,817.24284)" style="stroke-width:0.32031175">
+      <path d="m 0,0 -1.121,-16.063 c -0.135,-1.936 -1.675,-3.477 -3.611,-3.616 l -38.555,-2.751 c -0.094,-0.007 -0.188,-0.01 -0.281,-0.01 -1.916,0 -3.569,1.406 -3.852,3.33 l -2.211,14.994 H -81.09 l -2.211,-14.994 c -0.297,-2.018 -2.101,-3.469 -4.133,-3.32 l -38.555,2.751 c -1.936,0.139 -3.476,1.68 -3.611,3.616 L -130.721,0 -163.268,3.138 c 0.015,-3.498 0.06,-7.33 0.06,-8.093 0,-34.374 43.605,-50.896 97.781,-51.086 h 0.066 0.067 c 54.176,0.19 97.766,16.712 97.766,51.086 0,0.777 0.047,4.593 0.063,8.093 z" style="fill:#478cbf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.32031175" id="path88-5" inkscape:connector-curvature="0"/>
+    </g>
+    <g id="g90-3" transform="matrix(4.162611,0,0,-4.162611,389.21484,625.67104)" style="stroke-width:0.32031175">
+      <path d="m 0,0 c 0,-12.052 -9.765,-21.815 -21.813,-21.815 -12.042,0 -21.81,9.763 -21.81,21.815 0,12.044 9.768,21.802 21.81,21.802 C -9.765,21.802 0,12.044 0,0" style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.32031175" id="path92-5" inkscape:connector-curvature="0"/>
+    </g>
+    <g id="g94-6" transform="matrix(4.162611,0,0,-4.162611,367.36686,631.05679)" style="stroke-width:0.32031175">
+      <path d="m 0,0 c 0,-7.994 -6.479,-14.473 -14.479,-14.473 -7.996,0 -14.479,6.479 -14.479,14.473 0,7.994 6.483,14.479 14.479,14.479 C -6.479,14.479 0,7.994 0,0" style="fill:#414042;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.32031175" id="path96-2" inkscape:connector-curvature="0"/>
+    </g>
+    <g id="g98-9" transform="matrix(4.162611,0,0,-4.162611,511.99336,724.73954)" style="stroke-width:0.32031175">
+      <path d="m 0,0 c -3.878,0 -7.021,2.858 -7.021,6.381 v 20.081 c 0,3.52 3.143,6.381 7.021,6.381 3.878,0 7.028,-2.861 7.028,-6.381 V 6.381 C 7.028,2.858 3.878,0 0,0" style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.32031175" id="path100-1" inkscape:connector-curvature="0"/>
+    </g>
+    <g id="g102-2" transform="matrix(4.162611,0,0,-4.162611,634.78706,625.67104)" style="stroke-width:0.32031175">
+      <path d="m 0,0 c 0,-12.052 9.765,-21.815 21.815,-21.815 12.041,0 21.808,9.763 21.808,21.815 0,12.044 -9.767,21.802 -21.808,21.802 C 9.765,21.802 0,12.044 0,0" style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.32031175" id="path104-7" inkscape:connector-curvature="0"/>
+    </g>
+    <g id="g106-0" transform="matrix(4.162611,0,0,-4.162611,656.64056,631.05679)" style="stroke-width:0.32031175">
+      <path d="m 0,0 c 0,-7.994 6.477,-14.473 14.471,-14.473 8.002,0 14.479,6.479 14.479,14.473 0,7.994 -6.477,14.479 -14.479,14.479 C 6.477,14.479 0,7.994 0,0" style="fill:#414042;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.32031175" id="path108-9" inkscape:connector-curvature="0"/>
+    </g>
+  </g>
+</svg>

--- a/views/website/libraries/34-GDScript.json
+++ b/views/website/libraries/34-GDScript.json
@@ -31,7 +31,7 @@
         "eddsa": false
       },
       "authorUrl": "https://github.com/fenix-hub",
-      "authorName": "fenix-hub",
+      "authorName": "Nicolò Santilio",
       "gitHubRepoPath": "fenix-hub/godot-engine.jwt",
       "repoUrl": "https://github.com/fenix-hub/godot-engine.jwt",
       "installCommandHtml": "git clone https://github.com/fenix-hub/godot-engine.jwt"

--- a/views/website/libraries/34-GDScript.json
+++ b/views/website/libraries/34-GDScript.json
@@ -1,29 +1,11 @@
 {
-  // Language name (unique)
   "name": "GDScript",
-
-  // Unique identifier that will be used as a CSS class
-  // for this language (only valid CSS class names).
   "uniqueClass": "gdscript",
-
-  // The language icon, SVG format preferred, should be placed
-  // in /img directory.
   "image": "/img/34.svg",
-
-  // The color of header that displays the name of the language
-  // and the icon. This is a valid CSS color definition.
   "bgColor": "rgb(71, 140, 191)",
-
-  // An array of libraries for this language.
   "libs": [
     {
-      // In case the library suffered from a vulnerability, the
-      // minimum version in which the vuln was fixed must be
-      // listed here. Optional (can be null).
-      "minimumVersion": "1.4", // or null
-
-      // Supported features, true for supported,
-      // false for not supported.
+      "minimumVersion": "1.5",
       "support": {
         "sign": true,
         "verify": true,
@@ -48,22 +30,10 @@
         "ps512": false,
         "eddsa": false
       },
-
-      // Author URL, can be GitHub profile, personal page
-      // company page, etc. Can be null.
-      "authorUrl": "https://github.com/fenix-hub", // or null
-
-      // Author name.
+      "authorUrl": "https://github.com/fenix-hub",
       "authorName": "fenix-hub",
-
-      // For the star count, this is the GitHub repository path,
-      // (usually user/repo). Can be null (no star count shown).
-      "gitHubRepoPath": "fenix-hub/godot-engine.jwt", // or null
-
-      // URL for source code.
+      "gitHubRepoPath": "fenix-hub/godot-engine.jwt",
       "repoUrl": "https://github.com/fenix-hub/godot-engine.jwt",
-
-      // Install command, can be HTML or plain text.
       "installCommandHtml": "git clone https://github.com/fenix-hub/godot-engine.jwt"
     }
   ]

--- a/views/website/libraries/34-GDScript.json
+++ b/views/website/libraries/34-GDScript.json
@@ -37,7 +37,7 @@
         "hs256": true,
         "hs384": false,
         "hs512": false,
-        "rs256": false,
+        "rs256": true,
         "rs384": false,
         "rs512": false,
         "es256": false,

--- a/views/website/libraries/34-GDScript.json
+++ b/views/website/libraries/34-GDScript.json
@@ -5,7 +5,7 @@
   "bgColor": "rgb(71, 140, 191)",
   "libs": [
     {
-      "minimumVersion": "1.5",
+      "minimumVersion": "3.x",
       "support": {
         "sign": true,
         "verify": true,
@@ -34,6 +34,38 @@
       "authorName": "Nicolò Santilio",
       "gitHubRepoPath": "fenix-hub/godot-engine.jwt",
       "repoUrl": "https://github.com/fenix-hub/godot-engine.jwt",
+      "installCommandHtml": "git clone https://github.com/fenix-hub/godot-engine.jwt"
+    },
+    {
+      "minimumVersion": "4.x",
+      "support": {
+        "sign": true,
+        "verify": true,
+        "iss": true,
+        "sub": true,
+        "aud": true,
+        "exp": true,
+        "nbf": true,
+        "iat": true,
+        "jti": true,
+        "hs256": true,
+        "hs384": false,
+        "hs512": false,
+        "rs256": true,
+        "rs384": false,
+        "rs512": false,
+        "es256": false,
+        "es384": false,
+        "es512": false,
+        "ps256": false,
+        "ps384": false,
+        "ps512": false,
+        "eddsa": false
+      },
+      "authorUrl": "https://github.com/fenix-hub",
+      "authorName": "Nicolò Santilio",
+      "gitHubRepoPath": "fenix-hub/godot-engine.jwt",
+      "repoUrl": "https://github.com/fenix-hub/godot-engine.jwt/tree/main-godot4",
       "installCommandHtml": "git clone https://github.com/fenix-hub/godot-engine.jwt"
     }
   ]

--- a/views/website/libraries/34-GDScript.json
+++ b/views/website/libraries/34-GDScript.json
@@ -1,0 +1,70 @@
+{
+  // Language name (unique)
+  "name": "GDScript",
+
+  // Unique identifier that will be used as a CSS class
+  // for this language (only valid CSS class names).
+  "uniqueClass": "gdscript",
+
+  // The language icon, SVG format preferred, should be placed
+  // in /img directory.
+  "image": "/img/34.svg",
+
+  // The color of header that displays the name of the language
+  // and the icon. This is a valid CSS color definition.
+  "bgColor": "rgb(71, 140, 191)",
+
+  // An array of libraries for this language.
+  "libs": [
+    {
+      // In case the library suffered from a vulnerability, the
+      // minimum version in which the vuln was fixed must be
+      // listed here. Optional (can be null).
+      "minimumVersion": "1.4", // or null
+
+      // Supported features, true for supported,
+      // false for not supported.
+      "support": {
+        "sign": true,
+        "verify": true,
+        "iss": true,
+        "sub": true,
+        "aud": true,
+        "exp": true,
+        "nbf": true,
+        "iat": true,
+        "jti": true,
+        "hs256": true,
+        "hs384": false,
+        "hs512": false,
+        "rs256": false,
+        "rs384": false,
+        "rs512": false,
+        "es256": false,
+        "es384": false,
+        "es512": false,
+        "ps256": false,
+        "ps384": false,
+        "ps512": false,
+        "eddsa": false
+      },
+
+      // Author URL, can be GitHub profile, personal page
+      // company page, etc. Can be null.
+      "authorUrl": "https://github.com/fenix-hub", // or null
+
+      // Author name.
+      "authorName": "fenix-hub",
+
+      // For the star count, this is the GitHub repository path,
+      // (usually user/repo). Can be null (no star count shown).
+      "gitHubRepoPath": "fenix-hub/godot-engine.jwt", // or null
+
+      // URL for source code.
+      "repoUrl": "https://github.com/fenix-hub/godot-engine.jwt",
+
+      // Install command, can be HTML or plain text.
+      "installCommandHtml": "git clone https://github.com/fenix-hub/godot-engine.jwt"
+    }
+  ]
+}


### PR DESCRIPTION
Hi!
I'm writing a GDScript library to implement JWT in Godot Game Engine.
I'm following auth0 documentation, the RFC standard and I'm using some other libraries as a reference to make it homogeneous.
I'd like to add my library in the website's list.
I tried to test the website locally but couldn't manage to do it.