### PR TITLE
Add privacy links

### DIFF
--- a/stylus/website/index.styl
+++ b/stylus/website/index.styl
@@ -1244,6 +1244,11 @@ footer
   .logo 
     height 18px
 
+  .privacy-links
+    margin-bottom 16px
+    span
+      padding 0 6px
+
   .pull-request
     +breakpoint("tablet")
       text-align center

--- a/views/website/layout.pug
+++ b/views/website/layout.pug
@@ -51,6 +51,12 @@ html(lang='en')
       .container
         .columns
           .column
+            div.privacy-links
+              a(href='https://auth0.com/privacy/', target="_blank")
+                | Privacy
+              span •
+              a(href='https://auth0.com/web-terms', target="_blank")
+                | Terms of Service
             a(href='https://auth0.com/developers/', target="_blank")
               | Supported by
               img(src='/img/ico_logo.svg' alt='Supported by Auth0 - JWT.io Token Based Authentication').logo


### PR DESCRIPTION
### Description
- Added Privacy and Terms of Service links to footer:
<img width="1437" alt="jwt" src="https://user-images.githubusercontent.com/36993036/149534561-a15f13a7-bd0a-41c7-a47f-67639d297bb1.png">

