### PR TITLE
support unsecured jwt

### DIFF
--- a/src/dom-elements.js
+++ b/src/dom-elements.js
@@ -35,3 +35,5 @@ export const secretInput =
   document.querySelector('.jwt-signature input[name="secret"]');
 export const secretBase64Checkbox =
   document.getElementById('is-base64-encoded');
+export const signatureArea =
+  document.querySelector('.jwt-explained.jwt-signature')

--- a/src/editor/default-tokens.js
+++ b/src/editor/default-tokens.js
@@ -186,5 +186,10 @@ export default {
     privateKey: rsaPrivateKey,
     jwk: rsaJwk,
     publicKey: rsaPublicKey
+  },
+  none: {
+    token: 'eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.',
+    privateKey: '',
+    publicKey: ''
   }
 };

--- a/src/strings.js
+++ b/src/strings.js
@@ -46,6 +46,7 @@ export default {
     editor: {
         signatureVerified: 'signature verified',
         signatureInvalid: 'invalid signature',
+        unsecuredJwt: 'Unsecured JWT',
         jwtInvalid: 'Invalid JWT'
     },
     warnings: {

--- a/views/token-editor-algorithms.pug
+++ b/views/token-editor-algorithms.pug
@@ -11,3 +11,4 @@ select#algorithm-select
   option(name='algorithm',value='PS256') PS256
   option(name='algorithm',value='PS384') PS384
   option(name='algorithm',value='PS512') PS512
+  option(name='algorithm',value='none') none


### PR DESCRIPTION
resolves #577

adds debugger support for alg=none, unsecured JWT as per https://www.rfc-editor.org/rfc/rfc7519.html#section-6

Default token as well as pasted unsecured tokens get the "VERIFY SIGNATURE" area hidden and the whole status is marked red with "Unsecured JWT"

<img width="1191" alt="Screenshot 2022-03-18 at 11 47 04" src="https://user-images.githubusercontent.com/241506/158990241-495f79e9-4327-4f67-93fb-b77926771ebc.png">

