### PR TITLE
Update signatures for firebase/php-jwt

### DIFF
--- a/views/website/libraries/24-PHP.json
+++ b/views/website/libraries/24-PHP.json
@@ -23,11 +23,13 @@
         "rs384": true,
         "rs512": true,
         "es256": true,
-        "es384": false,
+        "es384": true,
         "es512": false,
         "ps256": false,
         "ps384": false,
-        "ps512": false
+        "ps512": false,
+        "eddsa": true,
+        "es256k": false
       },
       "authorUrl": "https://github.com/firebase",
       "authorName": "Firebase",


### PR DESCRIPTION
As of version 6.0.0, php-jwt supports ES384 and Ed25519 ([changelog](https://github.com/firebase/php-jwt#600--2022-01-24)).

As shown by the [source code](https://github.com/firebase/php-jwt/blob/v6.1.2/src/JWT.php#L56) in the latest release, es256k is not supported.