### PR TITLE
Adding support for jku and x5u claims

### DIFF
--- a/src/editor/jwt-iana-registered-claims.js
+++ b/src/editor/jwt-iana-registered-claims.js
@@ -6,6 +6,8 @@ export default [
   'nbf',
   'iat',
   'jti',
+  'jku',
+  'x5u',
   'name',
   'given_name',
   'family_name',

--- a/views/website/libraries/6-Ruby.json
+++ b/views/website/libraries/6-Ruby.json
@@ -16,6 +16,8 @@
         "nbf": true,
         "iat": true,
         "jti": true,
+        "jku": false,
+        "x5u": false,
         "hs256": true,
         "hs384": true,
         "hs512": true,

--- a/views/website/libraries/template.pug
+++ b/views/website/libraries/template.pug
@@ -48,6 +48,14 @@ article(data-accordion, class=`accordion ${lang.uniqueClass}`)
           i(class=lib.support.typ ? 'icon-budicon-500' : (lib.support.typ !== undefined ? 'icon-budicon-501' : 'icon-unknown'))
           code typ
           |  check
+        p
+          i(class=lib.support.x5u ? 'icon-budicon-500' : (lib.support.x5u !== undefined ? 'icon-budicon-501' : 'icon-unknown'))
+          code x5u
+          |  check
+        p
+          i(class=lib.support.jku ? 'icon-budicon-500' : (lib.support.jku !== undefined ? 'icon-budicon-501' : 'icon-unknown'))
+          code jku
+          |  check
       .column
         p
           i(class=lib.support.hs256 ? 'icon-budicon-500' : 'icon-budicon-501')


### PR DESCRIPTION
This commit adds support for jku and x5u claims as part of the information provided about libraries. 

