### PR TITLE
Add ES256K and EdDSA for Authlib

### DIFF
--- a/views/website/libraries/1-Python.json
+++ b/views/website/libraries/1-Python.json
@@ -125,7 +125,9 @@
         "es512": true,
         "ps256": true,
         "ps384": true,
-        "ps512": true
+        "ps512": true,
+        "eddsa": true,
+        "es256k": true
       },
       "authorUrl": "https://github.com/lepture",
       "authorName": "Hsiaoming Yang",


### PR DESCRIPTION
- EdDSA is implemented with spec RFC8037: https://docs.authlib.org/en/latest/specs/rfc8037.html
- ES256K is defined in RFC8812, but implemented in https://github.com/lepture/authlib/blob/master/authlib/jose/rfc7518/jws_algs.py#L212