### PR TITLE
bump jose4j to 0.9.3 (and lowercase eddsa)

### DIFF
--- a/views/website/libraries/3-Java.json
+++ b/views/website/libraries/3-Java.json
@@ -61,13 +61,13 @@
         "ps256": true,
         "ps384": true,
         "ps512": true,
-        "EdDSA": true
+        "eddsa": true
       },
       "authorUrl": "https://twitter.com/__b_c",
       "authorName": "Brian Campbell",
       "gitHubRepoPath": null,
       "repoUrl": "https://bitbucket.org/b_c/jose4j",
-      "installCommandHtml": "maven: org.bitbucket.b_c / jose4j / 0.9.0"
+      "installCommandHtml": "maven: org.bitbucket.b_c / jose4j / 0.9.3"
     },
     {
       "minimumVersion": null,


### PR DESCRIPTION
newer version of jose4j and it looks like `"eddsa": true` is needed rather than `"EdDSA": true`