### PR TITLE
Define explicitly node version 16 to be able to migrate to heroku 22 stack

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,9 @@
         "webpack-merge": "^4.2.1",
         "xhr-mock": "^2.4.1"
     },
+    "engines": {
+        "node": "16"
+    },
     "scripts": {
         "start": "node server.js",
         "test": "grunt test",


### PR DESCRIPTION
We don't have defined a default version for nodejs, if we upgrade to heroku stack 22 as a default it will use node 18 and with this version, the build fails. Right now with heroku stack 18 the default version is node 16. So it is the same just we have to explicitly define it for the new stack to make it work.