### PR TITLE
add `jwskate` Python lib

### DIFF
--- a/views/website/libraries/1-Python.json
+++ b/views/website/libraries/1-Python.json
@@ -134,6 +134,39 @@
       "gitHubRepoPath": "lepture/authlib",
       "repoUrl": "https://github.com/lepture/authlib",
       "installCommandHtml": "pip install authlib"
+    },
+    {
+      "minimumVersion": null,
+      "support": {
+        "sign": true,
+        "verify": true,
+        "iss": true,
+        "sub": true,
+        "aud": true,
+        "exp": true,
+        "nbf": true,
+        "iat": true,
+        "jti": true,
+        "hs256": true,
+        "hs384": true,
+        "hs512": true,
+        "rs256": true,
+        "rs384": true,
+        "rs512": true,
+        "es256": true,
+        "es384": true,
+        "es512": true,
+        "ps256": true,
+        "ps384": true,
+        "ps512": true,
+        "eddsa": true,
+        "es256k": true
+      },
+      "authorUrl": "https://github.com/guillp",
+      "authorName": "Guillaume Pujol",
+      "gitHubRepoPath": "guillp/jwskate",
+      "repoUrl": "https://github.com/guillp/jwskate",
+      "installCommandHtml": "pip install jwskate"
     }
   ]
 }


### PR DESCRIPTION
I would like to advertise a new Python lib I created, named `jwskate`, which implements the full JOSE specifications, including JWT and JWK, in what I believe is an easy-to-use and Pythonic module.

Please refer to https://github.com/guillp/jwskate for details.