### PR TITLE
Update Swift's JWTKit's supported algorithms

### DIFF
--- a/views/website/libraries/19-Swift.json
+++ b/views/website/libraries/19-Swift.json
@@ -65,8 +65,7 @@
       "authorName": "Vapor",
       "gitHubRepoPath": "vapor/jwt-kit",
       "repoUrl": "https://github.com/vapor/jwt-kit",
-      "installCommandHtml":
-        ".package(url: \"https://github.com/vapor/jwt-kit.git\", from: \"4.0.0\")"
+      "installCommandHtml": ".package(url: \"https://github.com/vapor/jwt-kit.git\", from: \"5.0.0\")"
     },
     {
       "minimumVersion": null,
@@ -129,7 +128,7 @@
       "gitHubRepoPath": "IBM-Swift/Swift-JWT",
       "repoUrl": "https://github.com/IBM-Swift/Swift-JWT",
       "installCommandHtml":
-        ".package(url:\"https://github.com/IBM-Swift/Swift-JWT\", from: \"3.5.0\")"
+      ".package(url:\"https://github.com/IBM-Swift/Swift-JWT\", from: \"3.5.0\")"
     },
     {
       "minimumVersion": null,

--- a/views/website/libraries/19-Swift.json
+++ b/views/website/libraries/19-Swift.json
@@ -47,6 +47,7 @@
         "nbf": true,
         "iat": true,
         "jti": true,
+        "typ": true,
         "hs256": true,
         "hs384": true,
         "hs512": true,

--- a/views/website/libraries/19-Swift.json
+++ b/views/website/libraries/19-Swift.json
@@ -56,9 +56,10 @@
         "es256": true,
         "es384": true,
         "es512": true,
-        "ps256": false,
-        "ps384": false,
-        "ps512": false
+        "ps256": true,
+        "ps384": true,
+        "ps512": true,
+        "eddsa": true
       },
       "authorUrl": "https://github.com/vapor",
       "authorName": "Vapor",

--- a/views/website/libraries/19-Swift.json
+++ b/views/website/libraries/19-Swift.json
@@ -127,8 +127,7 @@
       "authorName": "IBM Swift",
       "gitHubRepoPath": "IBM-Swift/Swift-JWT",
       "repoUrl": "https://github.com/IBM-Swift/Swift-JWT",
-      "installCommandHtml":
-      ".package(url:\"https://github.com/IBM-Swift/Swift-JWT\", from: \"3.5.0\")"
+      "installCommandHtml": ".package(url:\"https://github.com/IBM-Swift/Swift-JWT\", from: \"3.5.0\")"
     },
     {
       "minimumVersion": null,


### PR DESCRIPTION
As of version 5, JWTKit supports the PSS algorithm family. Also added EdDSA as that was there before too