### PR TITLE
Fix: Tippy Top Banner not closing on other pages

### DIFF
--- a/src/website/dom-elements-common.js
+++ b/src/website/dom-elements-common.js
@@ -1,2 +1,9 @@
-export const codeElements = document.querySelectorAll('.plain-text pre code');
-export const counterElement = document.querySelector('.counter');
+export const codeElements = document.querySelectorAll(".plain-text pre code");
+export const counterElement = document.querySelector(".counter");
+
+export const navbarElement = document.querySelector("nav.navbar");
+export const menuTriggerElement = document.querySelector(".menu-trigger");
+export const menuLinks = document.querySelectorAll(".navbar .menu a");
+export const menuScrollableLinks = navbarElement.querySelectorAll("a.scrollto");
+
+export const sectionElements = document.getElementsByTagName("section");

--- a/src/website/dom-elements.js
+++ b/src/website/dom-elements.js
@@ -1,14 +1,6 @@
 export * from '../dom-elements.js';
 export * from './dom-elements-common.js';
 
-export const navbarElement = document.querySelector('nav.navbar');
-export const menuTriggerElement = document.querySelector('.menu-trigger');
-export const menuLinks = document.querySelectorAll('.navbar .menu a');
-export const menuScrollableLinks =
-    navbarElement.querySelectorAll('a.scrollto');
-
-export const sectionElements = document.getElementsByTagName('section');
-
 export const extensionSection = document.querySelector('.update-site');
 export const ebookSection = document.querySelector('.jtw-ebook-banner');
 

--- a/src/website/introduction/index.js
+++ b/src/website/introduction/index.js
@@ -1,9 +1,11 @@
 import { CCPAModal } from "../ccpa-modal.js";
 import { setupJwtCounter } from "../counter.js";
 import { setupHighlighting } from "../highlighting.js";
+import { setupNavbar } from "../navbar.js";
 import { TopBanner } from "../top-banner.js";
 
 // Initialization
+setupNavbar();
 setupHighlighting();
 setupJwtCounter();
 CCPAModal();

--- a/src/website/introduction/index.js
+++ b/src/website/introduction/index.js
@@ -1,6 +1,8 @@
 import { setupHighlighting } from "../highlighting.js";
 import { setupJwtCounter } from "../counter.js";
+import { TopBanner } from "../top-banner.js";
 
 // Initialization
 setupHighlighting();
 setupJwtCounter();
+TopBanner();

--- a/src/website/introduction/index.js
+++ b/src/website/introduction/index.js
@@ -1,8 +1,10 @@
-import { setupHighlighting } from "../highlighting.js";
+import { CCPAModal } from "../ccpa-modal.js";
 import { setupJwtCounter } from "../counter.js";
+import { setupHighlighting } from "../highlighting.js";
 import { TopBanner } from "../top-banner.js";
 
 // Initialization
 setupHighlighting();
 setupJwtCounter();
+CCPAModal();
 TopBanner();

--- a/src/website/libraries/index.js
+++ b/src/website/libraries/index.js
@@ -1,10 +1,12 @@
-import { setupLibraries } from "./libraries.js";
-import { setupHighlighting } from "../highlighting.js";
+import { CCPAModal } from "../ccpa-modal.js";
 import { setupJwtCounter } from "../counter.js";
+import { setupHighlighting } from "../highlighting.js";
 import { TopBanner } from "../top-banner.js";
+import { setupLibraries } from "./libraries.js";
 
 // Initialization
 setupLibraries();
 setupHighlighting();
 setupJwtCounter();
+CCPAModal();
 TopBanner();

--- a/src/website/libraries/index.js
+++ b/src/website/libraries/index.js
@@ -1,8 +1,10 @@
 import { setupLibraries } from "./libraries.js";
 import { setupHighlighting } from "../highlighting.js";
 import { setupJwtCounter } from "../counter.js";
+import { TopBanner } from "../top-banner.js";
 
 // Initialization
 setupLibraries();
 setupHighlighting();
 setupJwtCounter();
+TopBanner();

--- a/src/website/libraries/index.js
+++ b/src/website/libraries/index.js
@@ -1,10 +1,12 @@
 import { CCPAModal } from "../ccpa-modal.js";
 import { setupJwtCounter } from "../counter.js";
 import { setupHighlighting } from "../highlighting.js";
+import { setupNavbar } from "../navbar.js";
 import { TopBanner } from "../top-banner.js";
 import { setupLibraries } from "./libraries.js";
 
 // Initialization
+setupNavbar();
 setupLibraries();
 setupHighlighting();
 setupJwtCounter();

--- a/src/website/navbar.js
+++ b/src/website/navbar.js
@@ -1,12 +1,12 @@
 import { getOffsetBoundingClientRect } from './utils.js';
 
-import { 
+import {
   navbarElement,
   menuTriggerElement,
   menuLinks,
   sectionElements,
   menuScrollableLinks
-} from './dom-elements.js';
+} from './dom-elements-common.js';
 
 export function setupNavbar() {
   window.addEventListener('scroll', () => {

--- a/src/website/smooth-scrolling.js
+++ b/src/website/smooth-scrolling.js
@@ -1,4 +1,4 @@
-import { menuScrollableLinks, navbarElement } from './dom-elements.js';
+import { menuScrollableLinks, navbarElement } from './dom-elements-common.js';
 import { isWideScreen } from '../utils.js';
 
 import $ from 'jquery';
@@ -9,7 +9,7 @@ import log from 'loglevel';
 // jQuery somewhere else.
 export function smoothScrollTo(element) {
   // TODO: don't use jQuery
-  
+
   const navHeight = $(navbarElement).height();
   const targetElement = $(element);
 


### PR DESCRIPTION
## Description

This PR does the following:
- Fixes the  tippy top banner not closing on the introduction and libraries pages
- Fixes the privacy choices modal not opening on the introduction and libraries pages
- Fixes the mobile navigation bar not opening on the introduction and libraries pages
