### PR TITLE
Updated mORMot library reference for Delphi

### DIFF
--- a/views/website/libraries/23-Delphi.json
+++ b/views/website/libraries/23-Delphi.json
@@ -51,6 +51,7 @@
         "nbf": true,
         "iat": true,
         "jti": true,
+        "typ": true,
         "hs256": true,
         "hs384": true,
         "hs512": true,
@@ -58,11 +59,13 @@
         "rs384": true,
         "rs512": true,
         "es256": true,
+        "es256k": true,
         "es384": true,
         "es512": true,
         "ps256": true,
         "ps384": true,
-        "ps512": true
+        "ps512": true,
+        "eddsa": true
       },
       "authorUrl": "https://github.com/synopse",
       "authorName": "Synopse",

--- a/views/website/libraries/23-Delphi.json
+++ b/views/website/libraries/23-Delphi.json
@@ -52,23 +52,23 @@
         "iat": true,
         "jti": true,
         "hs256": true,
-        "hs384": false,
-        "hs512": false,
-        "rs256": false,
-        "rs384": false,
-        "rs512": false,
+        "hs384": true,
+        "hs512": true,
+        "rs256": true,
+        "rs384": true,
+        "rs512": true,
         "es256": true,
-        "es384": false,
-        "es512": false,
-        "ps256": false,
-        "ps384": false,
-        "ps512": false
+        "es384": true,
+        "es512": true,
+        "ps256": true,
+        "ps384": true,
+        "ps512": true
       },
       "authorUrl": "https://github.com/synopse",
       "authorName": "Synopse",
-      "gitHubRepoPath": "synopse/mORMot",
-      "repoUrl": "https://github.com/synopse/mORMot",
-      "installCommandHtml": "git clone https://github.com/synopse/mORMot"
+      "gitHubRepoPath": "synopse/mORMot2",
+      "repoUrl": "https://github.com/synopse/mORMot2",
+      "installCommandHtml": "git clone https://github.com/synopse/mORMot2"
     }
   ]
 }


### PR DESCRIPTION
Update 23-Delphi.json to reflect the mORMot 2 library repository, which now features all JWT algorithms.