### PR TITLE
Update 16-D.json to remove zolamk/jwt

### DIFF
--- a/views/website/libraries/16-D.json
+++ b/views/website/libraries/16-D.json
@@ -34,37 +34,6 @@
       "gitHubRepoPath": "olehlong/jwtd",
       "repoUrl": "https://github.com/olehlong/jwtd",
       "installCommandHtml": "dub fetch jwtd"
-    },
-    {
-      "minimumVersion": null,
-      "support": {
-        "sign": true,
-        "verify": true,
-        "iss": false,
-        "sub": false,
-        "aud": false,
-        "exp": true,
-        "nbf": true,
-        "iat": false,
-        "jti": false,
-        "hs256": true,
-        "hs384": true,
-        "hs512": true,
-        "rs256": false,
-        "rs384": false,
-        "rs512": false,
-        "es256": false,
-        "es384": false,
-        "es512": false,
-        "ps256": false,
-        "ps384": false,
-        "ps512": false
-      },
-      "authorUrl": "https://github.com/zolamk",
-      "authorName": "zolamk",
-      "gitHubRepoPath": "zolamk/jwt",
-      "repoUrl": "https://github.com/zolamk/jwt",
-      "installCommandHtml": "dub fetch jwt"
     }
   ]
 }


### PR DESCRIPTION
The project zolamk/jwt has not been active for seven years and was archived in 2018.

To minimize the risk of developers relying on outdated and unmaintained software, it should be removed from the list of libraries.