### PR TITLE
Add joserfc python library

### DIFF
--- a/views/website/libraries/1-Python.json
+++ b/views/website/libraries/1-Python.json
@@ -134,6 +134,40 @@
       "gitHubRepoPath": "lepture/authlib",
       "repoUrl": "https://github.com/lepture/authlib",
       "installCommandHtml": "pip install authlib"
+    },
+    {
+      "minimumVersion": null,
+      "support": {
+        "sign": true,
+        "verify": true,
+        "iss": true,
+        "sub": true,
+        "aud": true,
+        "exp": true,
+        "nbf": true,
+        "iat": true,
+        "jti": true,
+        "typ": true,
+        "hs256": true,
+        "hs384": true,
+        "hs512": true,
+        "rs256": true,
+        "rs384": true,
+        "rs512": true,
+        "es256": true,
+        "es384": true,
+        "es512": true,
+        "ps256": true,
+        "ps384": true,
+        "ps512": true,
+        "eddsa": true,
+        "es256k": true
+      },
+      "authorUrl": "https://github.com/lepture",
+      "authorName": "Hsiaoming Yang",
+      "gitHubRepoPath": "authlib/joserfc",
+      "repoUrl": "https://github.com/authlib/joserfc",
+      "installCommandHtml": "pip install joserfc"
     }
   ]
 }


### PR DESCRIPTION
joserfc is derived from Authlib, but features a redesigned API specific to JOSE functionality.