### PR TITLE
Update lcobucci/jwt support for PS tokens

### DIFF
--- a/src/data/libraries-next.json
+++ b/src/data/libraries-next.json
@@ -2768,9 +2768,9 @@
           "es256": true,
           "es384": true,
           "es512": true,
-          "ps256": false,
-          "ps384": false,
-          "ps512": false
+          "ps256": true,
+          "ps384": true,
+          "ps512": true
         },
         "authorUrl": "https://github.com/lcobucci",
         "authorName": "Luís Cobucci",


### PR DESCRIPTION
There is a dedicated package at https://github.com/lcobucci/jwt-rsassa-pss offering support that integrates with the main package.

This replaces #733 and adapts to the new V2 site structure from two weeks ago.