### PR TITLE
Fix author name overlap in library page

### DIFF
--- a/src/features/libraries/components/library-card/library-card..module.scss
+++ b/src/features/libraries/components/library-card/library-card..module.scss
@@ -103,6 +103,7 @@
   font-weight: 500;
   line-height: 140%;
   letter-spacing: 0.18px;
+  white-space: nowrap;
 
   svg {
     path {


### PR DESCRIPTION
Added `whitespace: nowrap` to library metadata container to handle large texts that overlap

**Before**
<img width="344" alt="Screenshot 2025-06-25 at 2 46 24 PM" src="https://github.com/user-attachments/assets/33f775ac-216a-411e-a9fa-03be357498d6" />

**After**
<img width="334" alt="Screenshot 2025-06-25 at 2 46 12 PM" src="https://github.com/user-attachments/assets/43b3a08d-555b-4ed5-877d-f996290c7e3d" />

