### PR TITLE
Add autofocus for jwt token input

### DIFF
--- a/src/features/common/components/checkbox/checkbox.component.tsx
+++ b/src/features/common/components/checkbox/checkbox.component.tsx
@@ -1,0 +1,28 @@
+import { Checkbox, type CheckboxProps } from "react-aria-components";
+import styles from './checkbox.module.scss'
+
+export function CheckboxComponent({
+  children,
+  ...props
+}: Omit<CheckboxProps, "children"> & {
+  children?: React.ReactNode;
+}) {
+  return (
+    <Checkbox {...props} className={styles.checkbox__component}>
+      {({ isIndeterminate }) => (
+        <>
+          <div className={styles.checkbox}>
+            <svg viewBox="0 0 18 18" aria-hidden="true">
+              {isIndeterminate ? (
+                <rect x={1} y={7.5} width={15} height={3} />
+              ) : (
+                <polyline points="1 9 7 14 15 4" />
+              )}
+            </svg>
+          </div>
+          {children}
+        </>
+      )}
+    </Checkbox>
+  );
+}

--- a/src/features/common/components/checkbox/checkbox.module.scss
+++ b/src/features/common/components/checkbox/checkbox.module.scss
@@ -1,0 +1,66 @@
+.checkbox__component {
+  --selected-color: var(--color_bg_state_success);
+  --selected-color-pressed: var(--color_fg_on_state_success_subtle);
+  --checkmark-color: var(--color_border_state_success);
+
+  display: flex;
+  /* This is needed so the HiddenInput is positioned correctly */
+  position: relative;
+  align-items: center;
+  gap: 0.571rem;
+  font-size: 1.143rem;
+  color: white;
+  forced-color-adjust: none;
+
+  .checkbox {
+    width: 1.143rem;
+    height: 1.143rem;
+    border: 2px solid var(--color_fg_default);
+    border-radius: 4px;
+    transition: all 200ms;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+  }
+
+  svg {
+    width: 1rem;
+    height: 1rem;
+    fill: none;
+    stroke: var(--functional-gray-0);
+    stroke-width: 3px;
+    stroke-dasharray: 22px;
+    stroke-dashoffset: 66;
+    transition: all 200ms;
+  }
+
+  &[data-focus-visible] .checkbox {
+    outline: 2px solid var(--color_fg_selected);
+    outline-offset: 2px;
+  }
+
+  &[data-selected],
+  &[data-indeterminate] {
+    .checkbox {
+      border-color: var(--selected-color);
+      background: var(--selected-color);
+    }
+
+    &[data-pressed] .checkbox {
+      border-color: var(--selected-color-pressed);
+      background: var(--selected-color-pressed);
+    }
+
+    svg {
+      stroke-dashoffset: 44;
+    }
+  }
+
+  &[data-indeterminate] {
+    & svg {
+      stroke: none;
+      fill: var(--checkmark-color);
+    }
+  }
+}

--- a/src/features/common/components/code-editor/editor.component.tsx
+++ b/src/features/common/components/code-editor/editor.component.tsx
@@ -18,6 +18,7 @@ type Props = React.HTMLAttributes<HTMLDivElement> & {
   textareaId?: string;
   textareaClassName?: string;
   autoFocus?: boolean;
+  focusOnWindowFocus?: boolean;
   disabled?: boolean;
   form?: string;
   maxLength?: number;
@@ -87,6 +88,15 @@ export class EditorComponent extends React.Component<Props, State> {
 
   componentDidMount() {
     this._recordCurrentState();
+    if (this.props.focusOnWindowFocus) {
+      window.addEventListener("focus", this._focusInput);
+    }
+  }
+
+  componentWillUnmount() {
+    if (this.props.focusOnWindowFocus) {
+      window.removeEventListener("focus", this._focusInput);
+    }
   }
 
   private _recordCurrentState = () => {
@@ -159,6 +169,13 @@ export class EditorComponent extends React.Component<Props, State> {
     // Add the new operation to the stack
     this._history.stack.push({ ...record, timestamp });
     this._history.offset++;
+  };
+
+  private _focusInput = () => {
+    const input = this._input;
+
+    if (!input) return;
+    input.focus();
   };
 
   private _updateInput = (record: Record) => {
@@ -466,7 +483,7 @@ export class EditorComponent extends React.Component<Props, State> {
         selectionStart,
         selectionEnd,
       },
-      true,
+      true
     );
 
     this.props.onValueChange(value);
@@ -516,6 +533,7 @@ export class EditorComponent extends React.Component<Props, State> {
       insertSpaces,
       ignoreTabKey,
       preClassName,
+      focusOnWindowFocus,
       ...rest
     } = this.props;
 

--- a/src/features/common/components/code-editor/editor.component.tsx
+++ b/src/features/common/components/code-editor/editor.component.tsx
@@ -93,10 +93,16 @@ export class EditorComponent extends React.Component<Props, State> {
     }
   }
 
-  componentWillUnmount() {
-    if (this.props.focusOnWindowFocus) {
-      window.removeEventListener("focus", this._focusInput);
+  componentDidUpdate(prevProps: Readonly<Props>): void {
+    if (prevProps.focusOnWindowFocus !== this.props.focusOnWindowFocus) {
+      this.props.focusOnWindowFocus
+        ? window.addEventListener("focus", this._focusInput)
+        : window.removeEventListener("focus", this._focusInput);
     }
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener("focus", this._focusInput);
   }
 
   private _recordCurrentState = () => {

--- a/src/features/debugger/components/debugger-toolbar/debugger-toolbar.component.tsx
+++ b/src/features/debugger/components/debugger-toolbar/debugger-toolbar.component.tsx
@@ -23,10 +23,6 @@ export const DebuggerToolbarComponent: React.FC<
   const setActiveWidget$ = useDebuggerStore((state) => state.setActiveWidget$);
   const isDecoder = activeWidget$ === DebuggerWidgetValues.DECODER;
   
-  useEffect(() => {
-    tabRefs.current[isDecoder ? 0 : 1]?.focus();
-  }, [isDecoder]);
-
   const handleKeyDown = (e: React.KeyboardEvent<HTMLLIElement>) => {
     const { key } = e;
 

--- a/src/features/debugger/components/debugger-toolbar/debugger-toolbar.component.tsx
+++ b/src/features/debugger/components/debugger-toolbar/debugger-toolbar.component.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import styles from "./debugger-toolbar.module.scss";
 import { BoxComponent } from "@/features/common/components/box/box.component";
 import { useDebuggerStore } from "@/features/debugger/services/debugger.store";
@@ -18,9 +18,26 @@ interface DebuggerToolbarComponentProps {
 export const DebuggerToolbarComponent: React.FC<
   DebuggerToolbarComponentProps
 > = ({ decoderDictionary, encoderDictionary, mode }) => {
+  const tabRefs = useRef<Array<HTMLLIElement | null>>([]);
   const activeWidget$ = useDebuggerStore((state) => state.activeWidget$);
-
   const setActiveWidget$ = useDebuggerStore((state) => state.setActiveWidget$);
+  const isDecoder = activeWidget$ === DebuggerWidgetValues.DECODER;
+  
+  useEffect(() => {
+    tabRefs.current[isDecoder ? 0 : 1]?.focus();
+  }, [isDecoder]);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLLIElement>) => {
+    const { key } = e;
+
+    if (key == "ArrowRight" || key == "ArrowLeft") {
+      setActiveWidget$(
+        isDecoder ? DebuggerWidgetValues.ENCODER : DebuggerWidgetValues.DECODER
+      );
+      e.preventDefault();
+    }
+    tabRefs.current[isDecoder ? 0 : 1]?.focus();
+  };
 
   if (mode === DebuggerModeValues.UNIFIED) {
     return (
@@ -40,8 +57,15 @@ export const DebuggerToolbarComponent: React.FC<
               onClick={() => {
                 setActiveWidget$(DebuggerWidgetValues.DECODER);
               }}
+              onKeyDown={handleKeyDown}
               data-active={activeWidget$ === DebuggerWidgetValues.DECODER}
               data-testid={dataTestidDictionary.debugger.decoderTab.id}
+              aria-selected={activeWidget$ === DebuggerWidgetValues.DECODER}
+              aria-controls={`${DebuggerWidgetValues.DECODER}-panel`}
+              ref={(el) => {
+                tabRefs.current[0] = el;
+              }}
+              tabIndex={activeWidget$ === DebuggerWidgetValues.DECODER ? 0 : -1}
             >
               <span className={styles.titleTab__compactLabel}>
                 {decoderDictionary.compactTitle}
@@ -53,11 +77,18 @@ export const DebuggerToolbarComponent: React.FC<
             <li
               role="tab"
               className={styles.titleTab}
+              onKeyDown={handleKeyDown}
               onClick={() => {
                 setActiveWidget$(DebuggerWidgetValues.ENCODER);
               }}
               data-active={activeWidget$ === DebuggerWidgetValues.ENCODER}
               data-testid={dataTestidDictionary.debugger.encoderTab.id}
+              aria-selected={activeWidget$ === DebuggerWidgetValues.ENCODER}
+              aria-controls={`${DebuggerWidgetValues.ENCODER}-panel`}
+              ref={(el) => {
+                tabRefs.current[1] = el;
+              }}
+              tabIndex={activeWidget$ === DebuggerWidgetValues.ENCODER ? 0 : -1}
             >
               <span className={styles.titleTab__compactLabel}>
                 {encoderDictionary.compactTitle}

--- a/src/features/decoder/components/jwt-editor.component.tsx
+++ b/src/features/decoder/components/jwt-editor.component.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { EditorComponent } from "@/features/common/components/code-editor/editor.component";
 
 interface JwtEditorComponentProps {
@@ -14,6 +14,8 @@ export const JwtEditorComponent: React.FC<JwtEditorComponentProps> = ({
     <EditorComponent
       aria-label="JWT editor input"
       value={token}
+      autoFocus
+      focusOnWindowFocus
       onValueChange={(code) => handleJwtChange(code)}
       highlight={(code) => {
         if (!code) {

--- a/src/features/decoder/components/jwt-editor.component.tsx
+++ b/src/features/decoder/components/jwt-editor.component.tsx
@@ -1,21 +1,23 @@
-import React, { useEffect } from "react";
+import React from "react";
 import { EditorComponent } from "@/features/common/components/code-editor/editor.component";
 
 interface JwtEditorComponentProps {
   token: string;
   handleJwtChange: (value: string) => void;
+  autoFocus: boolean
 }
 
 export const JwtEditorComponent: React.FC<JwtEditorComponentProps> = ({
   token,
+  autoFocus,
   handleJwtChange,
 }) => {
   return (
     <EditorComponent
       aria-label="JWT editor input"
       value={token}
-      autoFocus
-      focusOnWindowFocus
+      autoFocus={autoFocus}
+      focusOnWindowFocus={autoFocus}
       onValueChange={(code) => handleJwtChange(code)}
       highlight={(code) => {
         if (!code) {

--- a/src/features/decoder/components/jwt-input.component.tsx
+++ b/src/features/decoder/components/jwt-input.component.tsx
@@ -14,6 +14,7 @@ import { CardToolbarComponent } from "@/features/common/components/card-toolbar/
 import { CardToolbarCopyButtonComponent } from "@/features/common/components/card-toolbar-buttons/card-toolbar-copy-button/card-toolbar-copy-button.component";
 import { CardToolbarClearButtonComponent } from "@/features/common/components/card-toolbar-buttons/card-toolbar-clear-button/card-toolbar-clear-button.component";
 import styles from "./jwt-input.module.scss";
+import { CheckboxComponent } from "@/features/common/components/checkbox/checkbox.component";
 
 type JwtInputComponentProps = {
   languageCode: string;
@@ -24,6 +25,10 @@ export const JwtInputComponent: React.FC<JwtInputComponentProps> = ({
   languageCode,
   dictionary,
 }) => {
+  const [autoFocusEnabled, setAutofocusEnabled] = useState(() => {
+    const saved = localStorage.getItem("autofocus-enabled");
+    return saved ? !!JSON.parse(saved) : false
+  });
   const handleJwtChange$ = useDecoderStore((state) => state.handleJwtChange);
   const jwt$ = useDecoderStore((state) => state.jwt);
   const decodeErrors$ = useDecoderStore((state) => state.decodingErrors);
@@ -31,7 +36,7 @@ export const JwtInputComponent: React.FC<JwtInputComponentProps> = ({
   const decoderInputs$ = useDebuggerStore((state) => state.decoderInputs$);
 
   const [token, setToken] = useState<string>(
-    decoderInputs$.jwt || DEFAULT_JWT.token,
+    decoderInputs$.jwt || DEFAULT_JWT.token
   );
 
   const clearValue = async () => {
@@ -46,13 +51,23 @@ export const JwtInputComponent: React.FC<JwtInputComponentProps> = ({
     handleJwtChange$(cleanValue);
   };
 
+  const handleCheckboxChange = (selected: boolean) => {
+    localStorage.setItem("autofocus-enabled", JSON.stringify(selected))
+    setAutofocusEnabled(selected)
+  }
+
   useEffect(() => {
     setToken(jwt$);
   }, [jwt$]);
 
   return (
     <>
-      <span className={styles.headline}>{dictionary.headline}</span>
+      <div style={{ display: "flex", justifyContent: "space-between" }}>
+        <span className={styles.headline}>{dictionary.headline}</span>
+        <CheckboxComponent isSelected={autoFocusEnabled} onChange={e => handleCheckboxChange(e)}>
+          <span className={styles.checkbox__label}>Enable auto-focus</span>
+        </CheckboxComponent>
+      </div>
       <CardComponent
         id={dataTestidDictionary.decoder.jwtEditor.id}
         languageCode={languageCode}
@@ -84,7 +99,7 @@ export const JwtInputComponent: React.FC<JwtInputComponentProps> = ({
           ),
         }}
       >
-        <JwtEditorComponent token={token} handleJwtChange={handleJwtChange} />
+        <JwtEditorComponent token={token} handleJwtChange={handleJwtChange} autoFocus={autoFocusEnabled}/>
       </CardComponent>
     </>
   );

--- a/src/features/decoder/components/jwt-input.module.scss
+++ b/src/features/decoder/components/jwt-input.module.scss
@@ -10,3 +10,11 @@
   font-weight: 500;
   letter-spacing: 0.24px;
 }
+
+.checkbox__label {
+  color: var(--color_fg_default);
+  font-size: 0.875rem;
+  line-height: 1.375rem;
+  font-weight: 500;
+  letter-spacing: 0.24px;
+}


### PR DESCRIPTION
This PR adds a new feature for the user to enable or disable autofocus on JWT input. 
This helps users who have reported they need to switch between tabs constantly to copy/paste tokens and use the mouse for manually focusing the input.
The new feature is optional, meaning the logical focus order won't be affected if the user doesn't want to
**Light teme:**
<img width="584" height="346" alt="image" src="https://github.com/user-attachments/assets/7a1aa8cd-97d2-43e9-8ebc-4ee877c45d87" />
**Dark theme**
<img width="584" height="355" alt="image" src="https://github.com/user-attachments/assets/e5fd8378-090c-4043-8ac7-500239430073" />

