### PR TITLE
Add type assertion function for grouped options type

### DIFF
--- a/src/features/common/components/debugger-picker/debugger-picker.component.tsx
+++ b/src/features/common/components/debugger-picker/debugger-picker.component.tsx
@@ -3,6 +3,7 @@ import styles from "./debugger-picker.module.scss";
 import Select, { SingleValue, OptionsOrGroups, GroupBase } from "react-select";
 import { DebuggerPickerOptionModel } from "@/features/common/models/debugger-picker-option.model";
 import { LibraryFilterLabel } from "@/features/libraries/models/library-filters.model";
+import { isGroupedOptionsType } from "./utils";
 
 
 interface PickerLabelProps {
@@ -16,7 +17,7 @@ const getGroupLabel = (
   >,
   selected: DebuggerPickerOptionModel
 ): LibraryFilterLabel | undefined => {
-  if (!Array.isArray(options)) return undefined;
+  if(!isGroupedOptionsType(options)) return undefined
 
   const group = (options as GroupBase<DebuggerPickerOptionModel>[]).find(
     (group) => group.options.some((opt) => opt.value === selected.value)

--- a/src/features/common/components/debugger-picker/utils.ts
+++ b/src/features/common/components/debugger-picker/utils.ts
@@ -1,0 +1,11 @@
+import { GroupBase, OptionsOrGroups } from "react-select";
+import { DebuggerPickerOptionModel } from "../../models/debugger-picker-option.model";
+
+export const isGroupedOptionsType = (
+  options: OptionsOrGroups<
+    DebuggerPickerOptionModel,
+    GroupBase<DebuggerPickerOptionModel>
+  >
+): options is GroupBase<DebuggerPickerOptionModel>[] => {
+    return "options" in options[0]
+};


### PR DESCRIPTION
The check for validating grouped options was wrong. I added an assertion to correctly identify the type and separate between grouped and single options. 