### PR TITLE
Remove secret length requirement

### DIFF
--- a/src/features/common/models/encoder-result.model.ts
+++ b/src/features/common/models/encoder-result.model.ts
@@ -1,0 +1,4 @@
+export interface EncoderResult {
+  jwt: string;
+  signingErrors: string[] | null;
+}

--- a/src/features/common/services/jwt.service.ts
+++ b/src/features/common/services/jwt.service.ts
@@ -836,7 +836,7 @@ export const getSymmetricSecretKeyByteArray = (
 
     const buffer = safeBase64urlToBufferResult.value;
 
-    const safeNewUint8ArrayResult = safeNewUint8ArrayFromBuffer(buffer);
+    const safeNewUint8ArrayResult = safeNewUint8ArrayFromBuffer(buffer.buffer);
 
     if (safeNewUint8ArrayResult.isErr()) {
       return err(safeNewUint8ArrayResult.error);

--- a/src/features/common/services/jwt.service.ts
+++ b/src/features/common/services/jwt.service.ts
@@ -836,7 +836,7 @@ export const getSymmetricSecretKeyByteArray = (
 
     const buffer = safeBase64urlToBufferResult.value;
 
-    const safeNewUint8ArrayResult = safeNewUint8ArrayFromBuffer(buffer.buffer);
+    const safeNewUint8ArrayResult = safeNewUint8ArrayFromBuffer(buffer);
 
     if (safeNewUint8ArrayResult.isErr()) {
       return err(safeNewUint8ArrayResult.error);

--- a/src/features/encoder/services/token-encoder.service.ts
+++ b/src/features/encoder/services/token-encoder.service.ts
@@ -36,6 +36,7 @@ import { AsymmetricKeyFormatValues } from "@/features/common/values/asymmetric-k
 import { useDebuggerStore } from "@/features/debugger/services/debugger.store";
 import { SigningAlgCategoryValues } from "@/features/common/values/signing-alg-category.values";
 import { EncoderInputsModel } from "@/features/debugger/models/encoder-inputs.model";
+import { EncoderResult } from "@/features/common/models/encoder-result.model";
 
 type EncodingHeaderErrors = {
   headerErrors: string[] | null;
@@ -67,11 +68,6 @@ type EncodingJwtErrors = {
   payloadErrors: string[] | null;
   encodingErrors: string[] | null;
 };
-
-type EncodingResult = {
-  jwt: string;
-  signingErrors: string[] | null;
-}
 
 class _TokenEncoderService {
   async selectEncodingExample(
@@ -490,7 +486,7 @@ class _TokenEncoderService {
     payload: DecodedJwtPayloadModel,
     key: string,
     encodingFormat: EncodingValues,
-  ): Promise<Result<EncodingResult, DebuggerErrorModel>> {
+  ): Promise<Result<EncoderResult, DebuggerErrorModel>> {
     if (!isHmacAlg(header.alg)) {
       return err({
         task: DebuggerTaskValues.ENCODE,
@@ -542,7 +538,7 @@ class _TokenEncoderService {
       });
     }
 
-    return ok<EncodingResult>({
+    return ok<EncoderResult>({
       jwt: signWithSymmetricSecretKeyResult.value,
       signingErrors: signingError,
     });
@@ -553,7 +549,7 @@ class _TokenEncoderService {
     payload: DecodedJwtPayloadModel,
     key: string,
     keyFormat: AsymmetricKeyFormatValues,
-  ): Promise<Result<EncodingResult, DebuggerErrorModel>> {
+  ): Promise<Result<EncoderResult, DebuggerErrorModel>> {
     if (isDigitalSignatureAlg(header.alg)) {
       if (!key) {
         return err({
@@ -716,7 +712,7 @@ class _TokenEncoderService {
     symmetricSecretKeyEncoding: EncodingValues;
   }): Promise<
     Result<
-      EncodingResult,
+      EncoderResult,
       EncodingSymmetricSecretKeyErrors
     >
   > {
@@ -892,7 +888,7 @@ class _TokenEncoderService {
         },
   ): Promise<
     Result<
-      EncodingResult,
+      EncoderResult,
       EncodingJwtErrors
     >
   > {
@@ -900,7 +896,7 @@ class _TokenEncoderService {
     const header = params.header;
     const payload = params.payload;
 
-    let encodeJWTResult: Result<EncodingResult, DebuggerErrorModel> | null = null;
+    let encodeJWTResult: Result<EncoderResult, DebuggerErrorModel> | null = null;
 
     if (algType === SigningAlgCategoryValues.ANY) {
       const symmetricSecretKey = params.symmetricSecretKey;
@@ -1027,7 +1023,7 @@ class _TokenEncoderService {
       }
     }
 
-    return ok<EncodingResult>({
+    return ok<EncoderResult>({
       jwt: encodeJWTResult.value.jwt,
       signingErrors: encodeJWTResult.value.signingErrors,
     });

--- a/tests/token-encoder.service.test.ts
+++ b/tests/token-encoder.service.test.ts
@@ -1,0 +1,59 @@
+import { EncodingValues } from "@/features/common/values/encoding.values";
+import { describe, expect, test } from "vitest";
+import { TokenEncoderService } from "@/features/encoder/services/token-encoder.service";
+import {
+  DefaultTokensValues,
+  DefaultTokenWithSecretModel,
+} from "@/features/common/values/default-tokens.values";
+import { EncoderResult } from "@/features/common/models/encoder-result.model";
+
+describe("processSymmetricSecretKey", () => {
+  describe("should encode a JWT for SYMMETRIC type with HMAC algorithm", () => {
+    test("should return an object with a jwt and signingErrors should be null", async () => {
+      const params = {
+        header: JSON.stringify({ alg: "HS256", typ: "JWT" }),
+        payload: JSON.stringify({
+          sub: "1234567890",
+          name: "John Doe",
+          admin: true,
+          iat: 1516239022,
+        }),
+        symmetricSecretKey: (
+          DefaultTokensValues.HS256 as DefaultTokenWithSecretModel
+        ).secret,
+        symmetricSecretKeyEncoding: EncodingValues.UTF8,
+      };
+      const result =
+        await TokenEncoderService.processSymmetricSecretKey(params);
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrapOr({})).toEqual({
+        jwt: DefaultTokensValues.HS256.token,
+        signingErrors: null,
+      });
+    });
+
+    test("should return an object with a jwt and signingErrors should not be null", async () => {
+      const params = {
+        header: JSON.stringify({ alg: "HS256", typ: "JWT" }),
+        payload: JSON.stringify({
+          sub: "1234567890",
+          name: "John Doe",
+          admin: true,
+          iat: 1516239022,
+        }),
+        symmetricSecretKey: "secret",
+        symmetricSecretKeyEncoding: EncodingValues.UTF8,
+      };
+      const algSize = 256;
+      const result =
+        await TokenEncoderService.processSymmetricSecretKey(params);
+
+      expect(result.isOk()).toBe(true);
+      expect((result.unwrapOr({}) as EncoderResult).jwt).not.toBeNull();
+      expect((result.unwrapOr({}) as EncoderResult).signingErrors).toEqual(
+        [`A key of ${algSize} bits or larger MUST be used with HS${algSize} as specified on [RFC 7518](https://datatracker.ietf.org/doc/html/rfc7518#section-3.2).`]
+      );
+    });
+  });
+});


### PR DESCRIPTION
This PR removes the minimum length requirement for the secret input when encoding a JWT.
The encoder will display the same error message as before but will still encode the jwt.
<img width="2880" height="1436" alt="image" src="https://github.com/user-attachments/assets/59e69fd9-b7f3-409f-bd74-5b3d660ad2d6" />
