### PR TITLE
Update repo URL for lib l8w8jwt

### DIFF
--- a/src/data/libraries-next.json
+++ b/src/data/libraries-next.json
@@ -444,12 +444,12 @@
           "es256k": true,
           "eddsa": true
         },
-        "authorUrl": "https://github.com/GlitchedPolygons",
+        "authorUrl": "https://codeberg.org/GlitchedPolygons",
         "authorName": "Glitched Polygons",
         "gitHubRepoPath": "GlitchedPolygons/l8w8jwt",
-        "repoUrl": "https://github.com/GlitchedPolygons/l8w8jwt",
+        "repoUrl": "https://codeberg.org/GlitchedPolygons/l8w8jwt",
         "installCommandMarkdown": [
-          "git clone [https://github.com/GlitchedPolygons/l8w8jwt.git](https://github.com/GlitchedPolygons/l8w8jwt)"
+          "git clone [https://codeberg.org/GlitchedPolygons/l8w8jwt.git](https://codeberg.org/GlitchedPolygons/l8w8jwt.git)"
         ],
         "stars": 130
       },


### PR DESCRIPTION
Replaced all instances of [`https://github.com/GlitchedPolygons/l8w8jwt`](https://github.com/GlitchedPolygons/l8w8jwt) URLs with [`https://codeberg.org/GlitchedPolygons/l8w8jwt`](https://codeberg.org/GlitchedPolygons/l8w8jwt) 

(we migrated all of our FOSS repos over to Codeberg e.V.)