### PR TITLE
disable experimental-strip-types on tests scripts and replace assert …

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -27,7 +27,7 @@ jobs:
               run: npx playwright install --with-deps
 
             - name: Run Playwright Tests
-              run: npx playwright test
+              run: NODE_OPTIONS="--no-experimental-strip-types" npx playwright test
             
             - name: Upload Playwright Traces
               if: failure()

--- a/e2e/decoder.spec.ts
+++ b/e2e/decoder.spec.ts
@@ -26,7 +26,7 @@ import {
 } from "./e2e.utils";
 import { MessageStatusValue, MessageTypeValue } from "./e2e.values";
 import { JwtDictionaryModel, JwtSignedWithDigitalModel } from "./e2e.models";
-import jwts from "./jwt.json" assert { type: "json" };
+import jwts from "./jwt.json" with { type: "json" };
 
 const TestJwts = (jwts as JwtDictionaryModel).byAlgorithm;
 

--- a/e2e/encoder.spec.ts
+++ b/e2e/encoder.spec.ts
@@ -15,7 +15,7 @@ import {
   getLang,
   switchToEncoderTab,
 } from "./e2e.utils";
-import jwts from "./jwt.json" assert { type: "json" };
+import jwts from "./jwt.json" with { type: "json" };
 import {
   JwtDictionaryModel,
   JwtSignedWithDigitalModel,

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "next lint",
     "test": "vitest",
     "coverage": "vitest run --coverage",
-    "playwright:test-ui": "npx playwright test --ui"
+    "playwright:test-ui": "NODE_OPTIONS=\"--no-experimental-strip-types\" npx playwright test --ui"
   },
   "dependencies": {
     "@formatjs/intl-localematcher": "^0.5.7",


### PR DESCRIPTION
This PR disables experimental-strip-types on tests scripts and replaces `assert` for `with` on e2e tests