### PR TITLE
Add new Ed25519 and Ed448 algorithms from RFC 9864

### DIFF
--- a/src/data/libraries-next.json
+++ b/src/data/libraries-next.json
@@ -3251,7 +3251,9 @@
           "ps384": true,
           "ps512": true,
           "eddsa": true,
-          "es256k": true
+          "es256k": true,
+          "ed25519": true,
+          "ed448": true
         },
         "authorUrl": "https://github.com/simo5",
         "authorName": "Simo Sorce",

--- a/src/features/libraries/components/library-card/library-card.component.tsx
+++ b/src/features/libraries/components/library-card/library-card.component.tsx
@@ -185,6 +185,8 @@ export const LibraryCardComponent: React.FC<LibraryCardComponentProps> = ({
           <AlgItemComponent label="PS384" isSupported={support.ps384} />
           <AlgItemComponent label="PS512" isSupported={support.ps512} />
           <AlgItemComponent label="EdDSA" isSupported={support.eddsa} />
+          <AlgItemComponent label="Ed25519" isSupported={support.ed25519} />
+          <AlgItemComponent label="Ed448" isSupported={support.ed448} />
         </ul>
       </div>
       <div className={styles.metadata}>

--- a/src/features/libraries/models/library.model.ts
+++ b/src/features/libraries/models/library.model.ts
@@ -25,6 +25,8 @@ export interface LibraryModel {
     ps512?: boolean;
     eddsa?: boolean;
     es256k?: boolean;
+    ed25519?: boolean;
+    ed448?: boolean;
   };
   authorUrl: string | null;
   authorName: string;


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

[RFC 9864 (Fully-Specified Algorithms for JOSE and COSE)](https://www.rfc-editor.org/rfc/rfc9864.html) introduces `Ed25519` and `Ed448` as distinct, fully-specified `alg` identifiers, deprecating the polymorphic `EdDSA` identifier.

Adds `ed25519`/`ed448` as new algorithm-support fields end-to-end in the libraries directory:
- `LibraryModel["support"]` gains `ed25519?: boolean` and `ed448?: boolean`.
- `LibraryCardComponent` renders an `Ed25519` and `Ed448` row alongside the existing `EdDSA` row.
- `jwcrypto` is marked as supporting both, matching its upstream implementation ([latchset/jwcrypto#370](https://github.com/latchset/jwcrypto/pull/370)).

**Scope is limited to adding these two algorithm fields across the type, component, and jwcrypto's data entry.** No existing algorithm flags, labels, or library entries are changed.

### References

- [RFC 9864](https://www.rfc-editor.org/rfc/rfc9864.html)
- [latchset/jwcrypto#370](https://github.com/latchset/jwcrypto/pull/370)

### Testing

- **Manual verification:** confirmed the `jwcrypto` card renders green checks for Ed25519/Ed448, and libraries without this data render the neutral unsupported icon rather than breaking.
- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
