### PR TITLE
Added Dracarys JWT Library

### DIFF
--- a/src/data/libraries-next.json
+++ b/src/data/libraries-next.json
@@ -2715,6 +2715,40 @@
     "image": "/img/5.svg",
     "bgColor": "rgb(119, 123, 180)",
     "libs": [
+    {
+        "minimumVersion": "1.0.0",
+        "support": {
+          "sign": true,
+          "verify": true,
+          "iss": true,
+          "sub": true,
+          "aud": true,
+          "exp": true,
+          "nbf": true,
+          "iat": true,
+          "jti": false,
+          "hs256": true,
+          "hs384": true,
+          "hs512": true,
+          "rs256": true,
+          "rs384": false,
+          "rs512": false,
+          "es256": false,
+          "es384": false,
+          "es512": false,
+          "ps256": false,
+          "ps384": false,
+          "ps512": false,
+          "eddsa": false,
+          "es256k": false
+        },
+        "authorUrl": "https://github.com/Jushiro012623",
+        "authorName": "Ivan Macabontoc",
+        "gitHubRepoPath": "dracarys-jwt",
+        "repoUrl": "https://github.com/dracarys-jwt",
+        "installCommandMarkdown": ["composer require dracarys/jwt"],
+        "stars": 2
+      },
       {
         "minimumVersion": "2.0.0",
         "support": {


### PR DESCRIPTION
Add Dracarys JWT library for PHP 8+


- Lightweight JWT library with symmetric (HMAC) and asymmetric (RSA) support
- 
- Fluent API for creating, parsing, and validating tokens
- 
- Full support for standard JWT claims (iss, sub, aud, iat, exp, nbf, jti)
- 
- Custom claims and validation rules
- 
- Dependency-free, modern PHP 8+ compatible
- 
- Includes examples for token creation, parsing, and validation