### PR TITLE
chore: remove JP font

### DIFF
--- a/src/libs/theme/fonts.tsx
+++ b/src/libs/theme/fonts.tsx
@@ -36,26 +36,7 @@ export const MonoFont = Roboto_Mono({
   variable: "--font-mono",
 });
 
-export const JapaneseFont = localFont({
-  src: [
-    {
-      path: "./fonts/NotoSansJP-Regular.otf",
-      weight: "400",
-      style: "normal",
-    },
-    {
-      path: "./fonts/NotoSansJP-Medium.otf",
-      weight: "500",
-      style: "normal",
-    },
-    {
-      path: "./fonts/NotoSansJP-Bold.otf",
-      weight: "600",
-      style: "normal",
-    },
-  ],
-  variable: "--font-japanese",
-});
+export const JapaneseFont = SecondaryFont;
 
 export const getLocalizedSecondaryFont = (language: string) =>
   language === "ja" ? JapaneseFont.className : SecondaryFont.className;


### PR DESCRIPTION
The secondary Aeonic font already contains JP characters, so we don't need to load an additional font.