### PR TITLE
Add JWSETKit to Swift libraries

### DIFF
--- a/views/website/libraries/19-Swift.json
+++ b/views/website/libraries/19-Swift.json
@@ -195,6 +195,41 @@
       "repoUrl": "https://github.com/beatt83/jose-swift",
       "installCommandHtml":
         ".package(url: \"https://github.com/beatt83/jose-swift.git\", .upToNextMinor(from: \"4.0.0\"))"
+    },
+    {
+      "minimumVersion": null,
+      "support": {
+        "sign": true,
+        "verify": true,
+        "iss": true,
+        "sub": true,
+        "aud": true,
+        "exp": true,
+        "nbf": true,
+        "iat": true,
+        "jti": true,
+        "typ": true,
+        "hs256": true,
+        "hs384": true,
+        "hs512": true,
+        "rs256": true,
+        "rs384": true,
+        "rs512": true,
+        "es256": true,
+        "es384": true,
+        "es512": true,
+        "es256k": true,
+        "ps256": true,
+        "ps384": true,
+        "ps512": true,
+        "eddsa": true
+      },
+      "authorUrl": "https://github.com/amosavian",
+      "authorName": "Amir Abbas Mousavian",
+      "gitHubRepoPath": "amosavian/JWSETKit",
+      "repoUrl": "https://github.com/amosavian/JWSETKit",
+      "installCommandHtml":
+        ".package(url: \"https://github.com/amosavian/JWSETKit\", from: \"2.0.0\")"
     }
   ]
 }


### PR DESCRIPTION
Adds **JWSETKit** to the Swift libraries list.

- **Repo:** https://github.com/amosavian/JWSETKit
- **Docs:** https://swiftpackageindex.com/amosavian/JWSETKit/documentation
- **License:** MIT
- **Install:** Swift Package Manager (`from: "2.0.0"`)

JWSETKit is an actively maintained, type-safe Swift implementation of the JOSE
standards (JWS, JWE, JWT, JWK, SD-JWT) built on Apple CryptoKit / swift-crypto,
with Linux support.

The capability flags mirror the most complete existing Swift entry
(`jose-swift`): signing/verification, the standard registered claims, `typ`,
the full HS/RS/ES/PS algorithm families, `ES256K`, and `EdDSA`. (The table
schema can't express JWSETKit's additional support for JWE, SD-JWT, HPKE, and
ML-DSA.)

The change is a single additive entry in `views/website/libraries/19-Swift.json`;
the file remains valid JSON and no existing entries are modified.
