### PR TITLE
Add JWSETKit to Swift libraries

### DIFF
--- a/src/data/libraries-next.json
+++ b/src/data/libraries-next.json
@@ -3996,6 +3996,43 @@
           ".package(url: \"https://github.com/beatt83/jose-swift.git\", from: \"2.4.0\")"
         ],
         "stars": 21
+      },
+      {
+        "minimumVersion": null,
+        "support": {
+          "sign": true,
+          "verify": true,
+          "iss": true,
+          "sub": true,
+          "aud": true,
+          "exp": true,
+          "nbf": true,
+          "iat": true,
+          "jti": true,
+          "typ": true,
+          "hs256": true,
+          "hs384": true,
+          "hs512": true,
+          "rs256": true,
+          "rs384": true,
+          "rs512": true,
+          "es256": true,
+          "es384": true,
+          "es512": true,
+          "es256k": true,
+          "ps256": true,
+          "ps384": true,
+          "ps512": true,
+          "eddsa": true
+        },
+        "authorUrl": "https://github.com/amosavian",
+        "authorName": "Amir Abbas Mousavian",
+        "gitHubRepoPath": "amosavian/JWSETKit",
+        "repoUrl": "https://github.com/amosavian/JWSETKit",
+        "installCommandMarkdown": [
+          ".package(url: \"https://github.com/amosavian/JWSETKit\", from: \"2.0.0\")"
+        ],
+        "stars": 67
       }
     ]
   }


### PR DESCRIPTION
I am the maintainer of JWSETKit and would like to add it to the Swift libraries list.

https://github.com/amosavian/JWSETKit

It is an actively maintained Swift implementation of JWS, JWE, JWT, JWK and SD-JWT built on swift-crypto / CryptoKit, with Linux support. Support flags follow the current schema (sign/verify, registered claims, `typ`, HS/RS/ES/PS, `es256k`, `eddsa`).
