### PR TITLE
fix: ensure listbox visibility before interacting with options in JWT.

### DIFF
--- a/e2e/decoder.spec.ts
+++ b/e2e/decoder.spec.ts
@@ -122,6 +122,7 @@ test.describe("Can generate JWT examples", () => {
       );
 
       await pickerIndicator.click();
+      await page.getByRole("listbox").waitFor({ state: "visible" });
     });
 
     const options = Object.keys(DefaultTokensValues);
@@ -138,7 +139,7 @@ test.describe("Can generate JWT examples", () => {
         expectToBeNonNull(lang);
 
         const decoderWidget = page.getByTestId(dataTestidDictionary.decoder.id);
-        await page.getByRole("option", { name: option }).click();
+        await page.getByRole("listbox").getByRole("option", { name: option }).click();
 
         const targetToken = DefaultTokensValues[option];
 

--- a/e2e/encoder.spec.ts
+++ b/e2e/encoder.spec.ts
@@ -242,6 +242,7 @@ test.describe("Generate JWT encoding examples", () => {
       );
 
       await pickerIndicator.click();
+      await page.getByRole("listbox").waitFor({ state: "visible" });
     });
 
     const options = Object.keys(DefaultTokensValues);
@@ -255,7 +256,7 @@ test.describe("Generate JWT encoding examples", () => {
         }
 
         const encoder = page.getByTestId(dataTestidDictionary.encoder.id);
-        await page.getByRole("option", { name: option }).click();
+        await page.getByRole("listbox").getByRole("option", { name: option }).click();
 
         const jwtOutput = encoder
           .getByTestId(dataTestidDictionary.encoder.jwt.id)


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Fixes a race condition in the Playwright E2E test suites for the decoder and encoder "generate JWT example" tests, which caused 13 hard failures and 39 flaky tests on CI.

The `beforeEach` hook clicked the algorithm picker to open the react-select dropdown but did not wait for the dropdown to finish rendering before the individual test attempted to click an option. Playwright would resolve the option element, then lose it as react-select re-rendered — producing consistent `element was detached from the DOM` timeouts even after 3 retries.

The fix adds a `waitFor({ state: "visible" })` on the `listbox` role after opening the picker, ensuring the dropdown is fully rendered before any option interaction. The option click is also scoped to within the `listbox` container for added stability.

**Scope is limited to `e2e/decoder.spec.ts` and `e2e/encoder.spec.ts`:** no application logic, components, or library data are affected.

### References

N/A

### Testing

This is a test stability fix with no application logic changes:

- **CI verification:** the 13 previously hard-failing chromium decoder tests and 39 flaky encoder/decoder tests across chromium and firefox should now pass consistently without retries.
- No new application behavior to verify manually.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch