### PR TITLE
fix: stabilize algorithm picker e2e.

### DIFF
--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -23,20 +23,20 @@ jobs:
 
             - name: Run Vitest
               run: npx vitest run
-            
+
             - name: Install Playwright Browsers
               run: npx playwright install --with-deps
 
             - name: Run Playwright Tests
               run: NODE_OPTIONS="--no-experimental-strip-types" npx playwright test
-            
+
             - name: Upload Playwright Traces
               if: failure()
               uses: actions/upload-artifact@v4
               with:
                 name: playwright-traces
                 path: playwright-report/**/trace.zip
-    
+
   Deploy-Production:
     needs: test
     runs-on:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -34,6 +34,6 @@ jobs:
               uses: actions/upload-artifact@v4
               with:
                 name: playwright-traces
-                path: playwright-report/**/trace.zip
+                path: test-results/**/trace.zip
 
         

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,18 +22,16 @@ jobs:
 
             - name: Run Vitest
               run: npx vitest run
-            
+
             - name: Install Playwright Browsers
               run: npx playwright install --with-deps
 
             - name: Run Playwright Tests
               run: NODE_OPTIONS="--no-experimental-strip-types" npx playwright test
-            
+
             - name: Upload Playwright Traces
               if: failure()
               uses: actions/upload-artifact@v4
               with:
                 name: playwright-traces
                 path: test-results/**/trace.zip
-
-        

--- a/e2e/decoder.spec.ts
+++ b/e2e/decoder.spec.ts
@@ -116,13 +116,20 @@ test.describe("Can generate JWT examples", () => {
       const lang = await getLang(page);
       expectToBeNonNull(lang);
 
+      const algorithmPicker = page.getByRole("combobox", {
+        name: "Debugger picker",
+      });
+      const algorithmPickerRegion = page
+        .getByRole("region")
+        .filter({ has: algorithmPicker });
       const pickersUiDictionary = getPickersUiDictionary(lang);
       const pickerIndicator = page.getByText(
         pickersUiDictionary.exampleAlgPicker.defaultValue
       );
 
+      await expect(algorithmPickerRegion).toHaveAttribute("aria-busy", "false");
       await pickerIndicator.click();
-      await page.getByRole("listbox").waitFor({ state: "visible" });
+      await expect(page.getByRole("listbox")).toBeVisible();
     });
 
     const options = Object.keys(DefaultTokensValues);

--- a/e2e/encoder.spec.ts
+++ b/e2e/encoder.spec.ts
@@ -235,14 +235,20 @@ test.describe("Generate JWT encoding examples", () => {
       const lang = await getLang(page);
       expectToBeNonNull(lang);
 
+      const algorithmPicker = page.getByRole("combobox", {
+        name: "Debugger picker",
+      });
+      const algorithmPickerRegion = page
+        .getByRole("region")
+        .filter({ has: algorithmPicker });
       const pickersUiDictionary = getPickersUiDictionary(lang);
-
       const pickerIndicator = page.getByText(
         pickersUiDictionary.exampleAlgPicker.defaultValue
       );
 
+      await expect(algorithmPickerRegion).toHaveAttribute("aria-busy", "false");
       await pickerIndicator.click();
-      await page.getByRole("listbox").waitFor({ state: "visible" });
+      await expect(page.getByRole("listbox")).toBeVisible();
     });
 
     const options = Object.keys(DefaultTokensValues);

--- a/src/features/debugger/components/debugger-alg-picker/debugger-alg-picker.component.tsx
+++ b/src/features/debugger/components/debugger-alg-picker/debugger-alg-picker.component.tsx
@@ -64,9 +64,14 @@ export const WidgetAlgPickerComponent: React.FC<
   const [pickerState, setPickerState] = useState<PickerStates>(
     PickerStates.IDLE
   );
-  const [canUseEs512, setCanUseEs512] = useState(false);
-  const [canUseEd25519, setCanUseEd25519] = useState(false);
-  const [canUseEd448, setCanUseEd448] = useState(false);
+  const [capabilities, setCapabilities] = useState({
+    canUseEs512: false,
+    canUseEd25519: false,
+    canUseEd448: false,
+    isLoading: true,
+  });
+
+  const { canUseEs512, canUseEd25519, canUseEd448, isLoading } = capabilities;
 
   const dictionary = getPickersUiDictionary(languageCode);
 
@@ -93,16 +98,19 @@ export const WidgetAlgPickerComponent: React.FC<
   };
 
   useEffect(() => {
-    (async function runEs512Check() {
-      setCanUseEs512(await isP521Supported());
-    })();
+    (async function checkCapabilities() {
+      const [canUseEs512, canUseEd25519, canUseEd448] = await Promise.all([
+        isP521Supported(),
+        isEd25519Supported(),
+        isEd448Supported(),
+      ]);
 
-    (async function runEd25519Check() {
-      setCanUseEd25519(await isEd25519Supported());
-    })();
-
-    (async function runEd448Check() {
-      setCanUseEd448(await isEd448Supported());
+      setCapabilities({
+        canUseEs512,
+        canUseEd25519,
+        canUseEd448,
+        isLoading: false,
+      });
     })();
   }, []);
 
@@ -188,7 +196,12 @@ export const WidgetAlgPickerComponent: React.FC<
   }, [noneAlgOptions, asymmetricAlgOptions, symmetricAlgOptions]);
 
   return (
-    <div role="region" aria-label={label} className={styles.alg_picker}>
+    <div
+      role="region"
+      aria-label={label}
+      aria-busy={isLoading}
+      className={styles.alg_picker}
+    >
       <div className={styles.container}>
         <div className={styles.picker}>
           <div className={styles.picker__label}>


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Fixes a race condition in the Playwright E2E tests for the decoder and encoder "generate JWT example" workflows.

The algorithm picker performs asynchronous WebCrypto capability checks for P-521, Ed25519, and Ed448. Previously, each check updated component state independently. These updates rebuilt the options passed to `react-select` while Playwright was interacting with the open menu. As a result, Playwright could resolve an option and then lose it when the option was replaced in the DOM, producing `element is not stable` and `element was detached from the DOM` timeouts.

The fix runs the capability checks concurrently with `Promise.all` and applies their results in a single state update. The algorithm picker exposes its loading state through `aria-busy`, allowing the E2E setup to wait until capability detection is complete before opening the menu. The option locators remain scoped to the visible `listbox`.

The PR also corrects the Playwright trace artifact path in the test workflow. Traces are written under `test-results`, not `playwright-report`, so failed CI runs will now upload the generated trace files correctly.

**Scope is limited to algorithm-picker initialization, the related decoder and encoder E2E setup hooks, and CI trace collection.** Selection behavior, algorithm ordering, labels, and styling are unchanged.

### References

N/A

### Testing

- **Automated E2E verification:** all 28 affected Chromium decoder and encoder algorithm-example tests passed serially with one worker.
- **Type and editor verification:** no diagnostics were reported in the modified component or E2E files.
- **Manual verification:** confirmed that the algorithm picker opens and selects examples correctly in both Decoder and Encoder views.
- CI should verify the same workflows across Chromium and Firefox without relying on retries.

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch