### PR TITLE
miladrahimi/php-jwt: Update supported features

### DIFF
--- a/src/data/libraries-next.json
+++ b/src/data/libraries-next.json
@@ -2981,7 +2981,7 @@
         "stars": 284
       },
       {
-        "minimumVersion": null,
+        "minimumVersion": "3.3.0",
         "support": {
           "sign": true,
           "verify": true,
@@ -2992,25 +2992,28 @@
           "nbf": true,
           "iat": true,
           "jti": true,
+          "typ": true,
           "hs256": true,
           "hs384": true,
           "hs512": true,
           "rs256": true,
           "rs384": true,
           "rs512": true,
-          "es256": false,
-          "es384": false,
-          "es512": false,
-          "ps256": false,
-          "ps384": false,
-          "ps512": false
+          "es256": true,
+          "es384": true,
+          "es512": true,
+          "ps256": true,
+          "ps384": true,
+          "ps512": true,
+          "eddsa": true,
+          "es256k": true
         },
         "authorUrl": "https://github.com/miladrahimi",
         "authorName": "Milad Rahimi",
         "gitHubRepoPath": "miladrahimi/php-jwt",
         "repoUrl": "https://github.com/miladrahimi/php-jwt",
         "installCommandMarkdown": ["composer require miladrahimi/php-jwt"],
-        "stars": 60
+        "stars": 71
       },
       {
         "minimumVersion": "7.2.1",


### PR DESCRIPTION
Updates the listing for [miladrahimi/php-jwt](https://github.com/miladrahimi/php-jwt) to reflect the current state of the library as of [v3.3.0](https://github.com/miladrahimi/php-jwt/releases/tag/v3.3.0):

- **ES256, ES384, ES512** → supported ([src/Cryptography/Algorithms/Ecdsa](https://github.com/miladrahimi/php-jwt/tree/v3.3.0/src/Cryptography/Algorithms/Ecdsa))
- **PS256, PS384, PS512** → supported, added in v3.3.0 ([src/Cryptography/Algorithms/RsaPss](https://github.com/miladrahimi/php-jwt/tree/v3.3.0/src/Cryptography/Algorithms/RsaPss))
- **ES256K** → supported ([ES256KSigner](https://github.com/miladrahimi/php-jwt/blob/v3.3.0/src/Cryptography/Algorithms/Ecdsa/ES256KSigner.php))
- **EdDSA** → supported ([src/Cryptography/Algorithms/Eddsa](https://github.com/miladrahimi/php-jwt/tree/v3.3.0/src/Cryptography/Algorithms/Eddsa))
- **typ** → checked by the parser (requires the header field to be present and equal to `JWT`)
- `minimumVersion` set to `3.3.0` (the first release supporting the full matrix above)
- Star count refreshed (60 → 71)

All claim checks (`iss`, `sub`, `aud`, `exp`, `nbf`, `iat`, `jti`) and the HS/RS families were already listed and remain unchanged. Every algorithm and claim check is covered by the library's test suite, and the README examples are verified by tests.