### PR TITLE
miladrahimi/php-jwt: Add Ed25519 and Ed448 support

### DIFF
--- a/src/data/libraries-next.json
+++ b/src/data/libraries-next.json
@@ -2924,7 +2924,7 @@
         "installCommandMarkdown": ["composer require adhocore/jwt"]
       },
       {
-        "minimumVersion": "3.3.0",
+        "minimumVersion": "3.4.0",
         "support": {
           "sign": true,
           "verify": true,
@@ -2949,7 +2949,9 @@
           "ps384": true,
           "ps512": true,
           "eddsa": true,
-          "es256k": true
+          "es256k": true,
+          "ed25519": true,
+          "ed448": true
         },
         "authorUrl": "https://github.com/miladrahimi",
         "authorName": "Milad Rahimi",


### PR DESCRIPTION
Updates the listing for [miladrahimi/php-jwt](https://github.com/miladrahimi/php-jwt) to reflect the current state of the library as of [v3.4.0](https://github.com/miladrahimi/php-jwt/releases/tag/v3.4.0), which adds the [RFC 9864](https://datatracker.ietf.org/doc/rfc9864/) fully-specified EdDSA algorithm names:

- **Ed25519** → supported, added in v3.4.0 ([Ed25519Signer](https://github.com/miladrahimi/php-jwt/blob/v3.4.0/src/Cryptography/Algorithms/Eddsa/Ed25519Signer.php), [Ed25519Verifier](https://github.com/miladrahimi/php-jwt/blob/v3.4.0/src/Cryptography/Algorithms/Eddsa/Ed25519Verifier.php)) — same libsodium keys and signatures as the already-listed `EdDSA`, only the `alg` header differs
- **Ed448** → supported, added in v3.4.0 ([Ed448Signer](https://github.com/miladrahimi/php-jwt/blob/v3.4.0/src/Cryptography/Algorithms/Eddsa/Ed448Signer.php), [Ed448Verifier](https://github.com/miladrahimi/php-jwt/blob/v3.4.0/src/Cryptography/Algorithms/Eddsa/Ed448Verifier.php)) — EdDSA over Curve448 via OpenSSL, with dedicated [Ed448PrivateKey](https://github.com/miladrahimi/php-jwt/blob/v3.4.0/src/Cryptography/Keys/Ed448PrivateKey.php) / [Ed448PublicKey](https://github.com/miladrahimi/php-jwt/blob/v3.4.0/src/Cryptography/Keys/Ed448PublicKey.php) classes
- `minimumVersion` bumped `3.3.0` → `3.4.0` (the first release supporting the full matrix above)

Every other entry in the listing is unchanged and still accurate.

Verification:

- Signing and verification for both algorithms are covered by [Ed25519Test](https://github.com/miladrahimi/php-jwt/blob/v3.4.0/tests/Cryptography/Algorithms/Eddsa/Ed25519Test.php) and [Ed448Test](https://github.com/miladrahimi/php-jwt/blob/v3.4.0/tests/Cryptography/Algorithms/Eddsa/Ed448Test.php), plus cross-checks against externally generated tokens in [InteropTest](https://github.com/miladrahimi/php-jwt/blob/v3.4.0/tests/InteropTest.php).
- The [README](https://github.com/miladrahimi/php-jwt/tree/v3.4.0#ed25519-algorithm) documents both, and the runnable examples ([examples/ed25519.php](https://github.com/miladrahimi/php-jwt/blob/v3.4.0/examples/ed25519.php), [examples/ed448.php](https://github.com/miladrahimi/php-jwt/blob/v3.4.0/examples/ed448.php)) are themselves executed by the test suite.

Note on requirements, in case it matters for the listing: `Ed25519` needs `ext-sodium` (as `EdDSA` already does), and `Ed448` needs PHP 8.4+ for OpenSSL's Curve448 support — the key classes throw at construction otherwise. The ML-DSA entries are deliberately left `false`; the library does not implement them.
